### PR TITLE
Share button to re-pop modal

### DIFF
--- a/src/main/kotlin/sh/zachwal/dailygames/home/views/HomeView.kt
+++ b/src/main/kotlin/sh/zachwal/dailygames/home/views/HomeView.kt
@@ -1,9 +1,10 @@
 package sh.zachwal.dailygames.home.views
 
+import kotlinx.html.ButtonType
 import kotlinx.html.FormMethod.post
 import kotlinx.html.HTML
-import kotlinx.html.a
 import kotlinx.html.body
+import kotlinx.html.button
 import kotlinx.html.div
 import kotlinx.html.form
 import kotlinx.html.h1
@@ -61,7 +62,9 @@ data class HomeView(
                                     }
                                     div(classes = "d-flex $justifyClass") {
                                         if (shareTextModalView != null) {
-                                            a(href = "/?showModal=true", classes = "btn btn-secondary") {
+                                            button(classes = "btn btn-secondary") {
+                                                id = "share-text-button"
+                                                type = ButtonType.button
                                                 i(classes = "bi bi-box-arrow-up") {}
                                             }
                                         }

--- a/src/main/resources/static/src/js/home.js
+++ b/src/main/resources/static/src/js/home.js
@@ -23,4 +23,5 @@ window.onload = function () {
     if (window.location.href.indexOf("showModal") != -1) {
        popModal();
     }
+    $('#share-text-button').click(popModal);
 }


### PR DESCRIPTION
Adds a button that calls the `popModal()` function onClick, which re-pops the share text modal. Only does this if the share text modal is rendered in the page.