### PR TITLE
New exception type for cleaner Sentry

### DIFF
--- a/src/main/kotlin/sh/zachwal/dailygames/results/ConflictingPuzzleResultException.kt
+++ b/src/main/kotlin/sh/zachwal/dailygames/results/ConflictingPuzzleResultException.kt
@@ -1,0 +1,8 @@
+package sh.zachwal.dailygames.results
+
+import sh.zachwal.dailygames.db.jdbi.puzzle.Puzzle
+
+class ConflictingPuzzleResultException(
+    val puzzle: Puzzle,
+    val userId: Long,
+) : IllegalArgumentException("You have already submitted a result for puzzle ${puzzle.game.displayName()} #${puzzle.number}")

--- a/src/test/kotlin/sh/zachwal/dailygames/results/ResultServiceTest.kt
+++ b/src/test/kotlin/sh/zachwal/dailygames/results/ResultServiceTest.kt
@@ -236,7 +236,7 @@ class ResultServiceTest(
     fun `submitting a result twice throws a helpful error`() {
         resultService.createResult(fixtures.zach, worldle934)
 
-        val e = assertThrows<IllegalArgumentException> {
+        val e = assertThrows<ConflictingPuzzleResultException> {
             resultService.createResult(fixtures.zach, worldle934)
         }
 


### PR DESCRIPTION
All `IllegalArgumentException`s were getting mixed into one Sentry issue; make a new type for when a user submits a conflicting result.