### PR TITLE
Wrapped: Use actual stat value for average table

### DIFF
--- a/src/main/kotlin/sh/zachwal/dailygames/wrapped/WrappedService.kt
+++ b/src/main/kotlin/sh/zachwal/dailygames/wrapped/WrappedService.kt
@@ -124,7 +124,7 @@ class WrappedService @Inject constructor(
                     val rows = ranks.entries.map { (game, rank) ->
                         RanksTableRowView(
                             game = game,
-                            stat = wrappedInfo.pointsByGame[game] ?: 0,
+                            statText = (wrappedInfo.pointsByGame[game] ?: 0).toString(),
                             rank = rank,
                         )
                     }
@@ -139,7 +139,7 @@ class WrappedService @Inject constructor(
                     val rows = ranks.entries.map { (game, rank) ->
                         RanksTableRowView(
                             game = game,
-                            stat = wrappedInfo.averagesByGame[game]?.toInt() ?: 0,
+                            statText = (wrappedInfo.averagesByGame[game] ?: 0.0).toString(),
                             rank = rank,
                         )
                     }

--- a/src/main/kotlin/sh/zachwal/dailygames/wrapped/views/RanksTableSection.kt
+++ b/src/main/kotlin/sh/zachwal/dailygames/wrapped/views/RanksTableSection.kt
@@ -51,7 +51,7 @@ data class RanksTableSection(
 
 data class RanksTableRowView(
     val game: Game,
-    val stat: Int,
+    val statText: String,
     val rank: Int,
 ) : HTMLView<TBODY>() {
 
@@ -65,7 +65,7 @@ data class RanksTableRowView(
     override fun TBODY.render() {
         tr {
             th(scope = ThScope.row) { +"${game.emoji()} ${game.displayName()}" }
-            td { +"$stat" }
+            td { +statText }
             td { +rankText }
         }
     }


### PR DESCRIPTION
We had been rounding to the nearest int for the average, which isn't very fun:
![image](https://github.com/user-attachments/assets/90e7a531-f88d-43b4-b0a4-fa31cf555e4b)

Use the rounded-to-one-decimal value
![image](https://github.com/user-attachments/assets/fee188ba-1f47-451b-9266-0ed704ca0eed)
