### PR TITLE
Concurrent hashmap for username cache

### DIFF
--- a/src/main/kotlin/sh/zachwal/dailygames/users/UserService.kt
+++ b/src/main/kotlin/sh/zachwal/dailygames/users/UserService.kt
@@ -7,6 +7,7 @@ import org.slf4j.LoggerFactory
 import sh.zachwal.dailygames.db.dao.UserDAO
 import sh.zachwal.dailygames.db.dao.UserPreferencesDAO
 import sh.zachwal.dailygames.db.jdbi.User
+import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 
 class UserService @Inject constructor(
@@ -62,7 +63,7 @@ class UserService @Inject constructor(
     fun list(): List<User> = userDAO.listUsers()
 
     // TODO use a real cache library, maybe
-    private val userNameCache = mutableMapOf<Long, String?>()
+    private val userNameCache = ConcurrentHashMap<Long, String?>()
 
     fun getUsernameCached(userId: Long): String? {
         return userNameCache.computeIfAbsent(userId) { getUser(it)?.username }

--- a/src/main/kotlin/sh/zachwal/dailygames/wrapped/WrappedController.kt
+++ b/src/main/kotlin/sh/zachwal/dailygames/wrapped/WrappedController.kt
@@ -23,9 +23,10 @@ class WrappedController @Inject constructor(
             get {
                 val year = call.parameters.getOrFail("year").toInt()
                 val userId = currentUser(call, userService).id
+                val wrappedView = wrappedService.wrappedView(year, userId)
 
                 call.respondHtml {
-                    wrappedService.wrappedView(year, userId).renderIn(this)
+                    wrappedView.renderIn(this)
                 }
             }
         }
@@ -34,9 +35,10 @@ class WrappedController @Inject constructor(
             get {
                 val year = call.parameters.getOrFail("year").toInt()
                 val userId = call.parameters.getOrFail("userId").toLong()
+                val wrappedView = wrappedService.wrappedView(year, userId)
 
                 call.respondHtml {
-                    wrappedService.wrappedView(year, userId).renderIn(this)
+                    wrappedView.renderIn(this)
                 }
             }
         }


### PR DESCRIPTION
The username cache uses a normal mutable map. Two requests that both hit this map at the same time can cause a `ConcurrentModificationException` -- use a `ConcurrentHashMap` instead.