### PR TITLE
Wrapped: Fix scrolling

### DIFF
--- a/src/main/kotlin/sh/zachwal/dailygames/wrapped/WrappedService.kt
+++ b/src/main/kotlin/sh/zachwal/dailygames/wrapped/WrappedService.kt
@@ -47,31 +47,41 @@ class WrappedService @Inject constructor(
 
         logger.info("Generating Wrapped for $userName in $year using $wrappedInfo")
 
+        var wrappedIndex = 1
+
         return WrappedView(
             name = userName,
             year = year,
             sections = listOfNotNull(
-                WelcomeSection(year, userName),
+                WelcomeSection(
+                    year,
+                    userName,
+                    wrappedIndex++
+                ),
                 StatSection(
                     topText = "You played...",
                     stat = wrappedInfo.totalGamesPlayed,
                     bottomText = "...games this year.",
+                    wrappedIndex++
                 ),
                 StatSection(
                     topText = "That ranks...",
                     stat = wrappedInfo.totalGamesRank,
                     bottomText = "...across all players!",
+                    wrappedIndex++
                 ),
                 // points scored
                 StatSection(
                     topText = "You scored...",
                     stat = wrappedInfo.totalPoints,
                     bottomText = "...points this year.",
+                    wrappedIndex++
                 ),
                 StatSection(
                     topText = "That ranks...",
                     stat = wrappedInfo.totalPointsRank,
                     bottomText = "...overall!",
+                    wrappedIndex++
                 ),
                 wrappedInfo.favoriteGame.let {
                     val favoriteGameText = "${it.emoji()}${it.displayName()}${it.emoji()}"
@@ -80,6 +90,7 @@ class WrappedService @Inject constructor(
                         topText = "Your favorite game was...",
                         middleText = favoriteGameText,
                         bottomText = "...you played it $favoriteGamePlayCount times!",
+                        wrappedIndex = wrappedIndex++
                     )
                 },
                 wrappedInfo.bestDay?.let {
@@ -87,17 +98,20 @@ class WrappedService @Inject constructor(
                         topText = "Your best day was...",
                         middleText = it.format(bestDayFormatter),
                         bottomText = "...when you scored ${wrappedInfo.bestDayPoints} points!",
+                        wrappedIndex = wrappedIndex++
                     )
                 },
                 StatSection(
                     topText = "You played Daily Games for...",
                     stat = wrappedInfo.totalMinutes,
                     bottomText = "...minutes this year.",
+                    wrappedIndex = wrappedIndex++
                 ),
                 StatSection(
                     topText = "That's number...",
                     stat = wrappedInfo.totalMinutesRank,
                     bottomText = "... of all players!",
+                    wrappedIndex = wrappedIndex++
                 ),
                 wrappedInfo.bestGame?.let {
                     val bestGameText = "${it.emoji()}${it.displayName()}${it.emoji()}"
@@ -105,6 +119,7 @@ class WrappedService @Inject constructor(
                         topText = "Your best game was...",
                         middleText = bestGameText,
                         bottomText = "",
+                        wrappedIndex = wrappedIndex++
                     )
                 },
                 wrappedInfo.bestGame?.let {
@@ -114,11 +129,13 @@ class WrappedService @Inject constructor(
                         topText = "Your average ${it.displayName()} score was...",
                         middleText = bestGameAverage.toString(),
                         bottomText = "...which ranks #$bestGameRank!",
-                        fontSizeOverride = "35vw;"
+                        fontSizeOverride = "35vw;",
+                        wrappedIndex = wrappedIndex++
                     )
                 },
                 SummaryTableSection(
-                    wrappedInfo = wrappedInfo
+                    wrappedInfo = wrappedInfo,
+                    wrappedIndex = wrappedIndex++,
                 ),
                 wrappedInfo.ranksPerGameTotal.let { ranks ->
                     // Use Game.values() to get consistent ordering
@@ -135,7 +152,8 @@ class WrappedService @Inject constructor(
                         title = "Totals",
                         heading = "Points",
                         subHeading = null,
-                        rows = rows
+                        rows = rows,
+                        wrappedIndex = wrappedIndex++,
                     )
                 },
                 wrappedInfo.ranksPerGameAverage.let { ranks ->
@@ -153,7 +171,8 @@ class WrappedService @Inject constructor(
                         title = "Averages",
                         heading = "Average",
                         subHeading = "(min $MINIMUM_GAMES_FOR_AVERAGE games)",
-                        rows = rows
+                        rows = rows,
+                        wrappedIndex = wrappedIndex++,
                     )
                 },
             )

--- a/src/main/kotlin/sh/zachwal/dailygames/wrapped/views/RanksTableSection.kt
+++ b/src/main/kotlin/sh/zachwal/dailygames/wrapped/views/RanksTableSection.kt
@@ -18,9 +18,11 @@ data class RanksTableSection(
     val title: String,
     val heading: String,
     val subHeading: String?,
-    val rows: List<RanksTableRowView>
+    val rows: List<RanksTableRowView>,
+    val wrappedIndex: Int,
 ) : WrappedSection(
     height = "", // Don't force view height = 90
+    wrappedIndex = wrappedIndex,
 ) {
     override fun DIV.content() {
         h1 { +title }

--- a/src/main/kotlin/sh/zachwal/dailygames/wrapped/views/StatSection.kt
+++ b/src/main/kotlin/sh/zachwal/dailygames/wrapped/views/StatSection.kt
@@ -9,7 +9,8 @@ data class StatSection(
     val topText: String,
     val stat: Int,
     val bottomText: String,
-) : WrappedSection() {
+    val wrappedIndex: Int,
+) : WrappedSection(wrappedIndex = wrappedIndex) {
     override fun DIV.content() {
         h3(classes = "top-text") {
             +topText

--- a/src/main/kotlin/sh/zachwal/dailygames/wrapped/views/SummaryTableSection.kt
+++ b/src/main/kotlin/sh/zachwal/dailygames/wrapped/views/SummaryTableSection.kt
@@ -15,8 +15,10 @@ private val bestDayFormatter = DateTimeFormatter.ofPattern("M/d/yy")
 
 data class SummaryTableSection(
     val wrappedInfo: WrappedInfo,
+    val wrappedIndex: Int,
 ) : WrappedSection(
     height = "", // Don't force view height = 90
+    wrappedIndex = wrappedIndex,
 ) {
 
     private val rankString = when (wrappedInfo.totalPointsRank) {

--- a/src/main/kotlin/sh/zachwal/dailygames/wrapped/views/TextSection.kt
+++ b/src/main/kotlin/sh/zachwal/dailygames/wrapped/views/TextSection.kt
@@ -11,7 +11,8 @@ data class TextSection(
     val middleText: String,
     val bottomText: String,
     val fontSizeOverride: String? = null,
-) : WrappedSection() {
+    val wrappedIndex: Int,
+) : WrappedSection(wrappedIndex = wrappedIndex) {
     override fun DIV.content() {
         h3(classes = "top-text") {
             +topText

--- a/src/main/kotlin/sh/zachwal/dailygames/wrapped/views/WelcomeSection.kt
+++ b/src/main/kotlin/sh/zachwal/dailygames/wrapped/views/WelcomeSection.kt
@@ -8,7 +8,8 @@ import kotlinx.html.h3
 data class WelcomeSection(
     val year: Int,
     val name: String,
-) : WrappedSection() {
+    val wrappedIndex: Int,
+) : WrappedSection(wrappedIndex = wrappedIndex) {
     override fun DIV.content() {
         h1 {
             +year.toString()

--- a/src/main/kotlin/sh/zachwal/dailygames/wrapped/views/WrappedSection.kt
+++ b/src/main/kotlin/sh/zachwal/dailygames/wrapped/views/WrappedSection.kt
@@ -1,16 +1,23 @@
 package sh.zachwal.dailygames.wrapped.views
 
 import kotlinx.html.DIV
+import kotlinx.html.a
 import kotlinx.html.div
+import kotlinx.html.id
 import sh.zachwal.dailygames.shared_html.HTMLView
 
 abstract class WrappedSection(
     val height: String = "vh-90",
+    private val wrappedIndex: Int,
 ) : HTMLView<DIV>() {
     override fun DIV.render() {
-        div(classes = "row $height snapChild") {
-            div(classes = "col card vw-100 mt-3 mx-3 p-3 d-flex bg-dark-subtle $classes") {
-                content()
+        a(classes = "link-unstyled", href = "#wrapped-section-${wrappedIndex + 1}") {
+            div(classes = "row $height") {
+                id = "wrapped-section-$wrappedIndex"
+
+                div(classes = "col card vw-100 mt-3 mx-3 p-3 d-flex bg-dark-subtle $classes") {
+                    content()
+                }
             }
         }
     }

--- a/src/main/resources/static/src/css/wrapped.css
+++ b/src/main/resources/static/src/css/wrapped.css
@@ -1,9 +1,6 @@
-body, html {
-  scroll-snap-type: y mandatory;
-}
-
-.snapChild {
-  scroll-snap-align: start;
+.link-unstyled, .link-unstyled:link, .link-unstyled:hover {
+  color: inherit;
+  text-decoration: inherit;
 }
 
 .vh-90 {


### PR DESCRIPTION
Turn off scroll snapping. Tap to advance.

On real phones, the scroll-snap-type: mandatory was really janky -- scrolling back the other direction, it would jump around.

This simplifies it and lets you scroll normally, or tap the card to advance to the next one.