### PR TITLE
Wrapped: Re-fix snap scrolling

### DIFF
--- a/src/main/kotlin/sh/zachwal/dailygames/wrapped/views/WrappedSection.kt
+++ b/src/main/kotlin/sh/zachwal/dailygames/wrapped/views/WrappedSection.kt
@@ -12,7 +12,7 @@ abstract class WrappedSection(
 ) : HTMLView<DIV>() {
     override fun DIV.render() {
         a(classes = "link-unstyled", href = "#wrapped-section-${wrappedIndex + 1}") {
-            div(classes = "row $height") {
+            div(classes = "row $height snapChild") {
                 id = "wrapped-section-$wrappedIndex"
 
                 div(classes = "col card vw-100 mt-3 mx-3 p-3 d-flex bg-dark-subtle $classes") {

--- a/src/main/resources/static/src/css/wrapped.css
+++ b/src/main/resources/static/src/css/wrapped.css
@@ -1,3 +1,11 @@
+body, html {
+  scroll-snap-type: y mandatory;
+}
+
+.snapChild {
+  scroll-snap-align: start;
+}
+
 .link-unstyled, .link-unstyled:link, .link-unstyled:hover {
   color: inherit;
   text-decoration: inherit;

--- a/src/main/resources/static/src/js/wrapped.js
+++ b/src/main/resources/static/src/js/wrapped.js
@@ -69,9 +69,24 @@ function addWebShare() {
    });
 }
 
+// Override the height on each element so it's no longer based on vh
+// This way if the viewport height changes (like when you scroll), the height of the element won't change
+// Without this, the height of the elements change and the page jumps around
+function setElementHeights() {
+    const elements = Array.from(document.getElementsByClassName('vh-90'));
+    const initialHeight = window.innerHeight * 0.9;
+
+    for (const e of elements) {
+        e.style.height = initialHeight + 'px';
+        e.classList.remove('vh-90');
+    }
+}
+
 window.onload = function () {
     const counters = document.querySelectorAll('.animate');
     counters.forEach(counter => runOnFirstAppearance(counter, animate));
 
     addWebShare();
+
+    setElementHeights();
 };


### PR DESCRIPTION
I figured out that the issue with snap scrolling was using `90vh`. When you scroll up, the viewport height changes and all the elements change with it, so they jump around the page and the snapping makes the problem even worse.

So, when the page loads, calculate the correct height and set it, while removing the `vh-90` class.

See #100 