### PR TITLE
Upgrade to Ktor 2.2.4

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 val kotlinVersion = "1.8.22" // keep in sync with plugin version
-val ktorVersion = "2.0.3"
+val ktorVersion = "2.2.4"
 val logbackVersion = "1.2.5"
 val jdbiVersion = "3.14.4"
 

--- a/src/main/kotlin/sh/zachwal/dailygames/utils/KtorUtils.kt
+++ b/src/main/kotlin/sh/zachwal/dailygames/utils/KtorUtils.kt
@@ -11,7 +11,7 @@ import sh.zachwal.dailygames.db.jdbi.puzzle.Game
 
 fun ApplicationRequest.remote(): String {
     val clientHost = origin.remoteHost
-    val clientPort = origin.port
+    val clientPort = origin.serverPort
     return "$clientHost:$clientPort"
 }
 


### PR DESCRIPTION
## Summary
- Upgraded Ktor from 2.0.3 to 2.2.4
- Fixed deprecated `origin.port` → `origin.serverPort` in KtorUtils.kt

## Test plan
- [x] Project compiles successfully (`./gradlew assemble testClasses`)
- [x] All tests pass (`./gradlew test`)
- [x] Application starts successfully (`./gradlew run`)

## Migration notes
Reviewed the Ktor 2.0 to 2.2 migration guide and addressed all applicable changes:
- ✅ Cookies API - no changes needed (already compatible)
- ✅ Request address properties - fixed deprecated `origin.port` usage
- ✅ Configuration merging - not used in this codebase
- ✅ HTTP cache storage - not used in this codebase
- ✅ appendExpired - not used in this codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)