### PR TITLE
Decouple deployment from Jenkins: server-side CD via systemd timers

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,68 +27,6 @@ pipeline {
                 sh './gradlew build'
             }
         }
-        stage('test-release') {
-            steps {
-                // Clear test releases
-                sh "rm -rf ~testdailygames/releases/*"
-                // Create the release
-                sh "mkdir -p ~testdailygames/releases/$GIT_COMMIT"
-                sh "tar -xvf build/distributions/dailygames.tar -C ~testdailygames/releases/$GIT_COMMIT"
-                // Set it as current
-                sh "ln -s ~testdailygames/releases/$GIT_COMMIT ~testdailygames/releases/current"
-                // Restart the service (only has sudo permissions for this command)
-                sh "sudo systemctl restart testdailygames"
-            }
-        }
-        stage('migrate database - testdailygames') {
-            when {
-                expression { env.GIT_BRANCH == 'origin/main' }
-            }
-            steps {
-                // Copy migrations & script into ~testdailygames
-                sh "rm -rf ~testdailygames/migrations/*"
-                sh "cp -r db ~testdailygames/migrations"
-
-                // Run migrations as testdailygames
-                dir("/home/testdailygames/migrations/db") {
-                    sh "sudo -u testdailygames ./migrate.sh"
-                }
-            }
-        }
-        stage('migrate database - dailygames') {
-            when {
-                expression { env.GIT_BRANCH == 'origin/main' }
-            }
-            steps {
-                // Copy migrations & script into ~testdailygames
-                sh "rm -rf ~dailygames/migrations/*"
-                sh "cp -r db ~dailygames/migrations"
-
-                // Run migrations as testdailygames
-                dir("/home/dailygames/migrations/db") {
-                    sh "sudo -u dailygames ./migrate.sh"
-                }
-            }
-        }
-        stage('release') {
-            when {
-                expression { env.GIT_BRANCH == 'origin/main' }
-            }
-            steps {
-                // Delete all but the three most recent releases
-                sh "ls -t ~dailygames/releases | tail -n +4 | xargs -I {} rm -rf ~dailygames/releases/{}"
-
-                // Create the release
-                sh "mkdir -p ~dailygames/releases/$GIT_COMMIT"
-                sh "tar -xvf build/distributions/dailygames.tar -C ~dailygames/releases/$GIT_COMMIT"
-
-                // Set it as current
-                sh "rm -f ~dailygames/releases/current"
-                sh "ln -s ~dailygames/releases/$GIT_COMMIT ~dailygames/releases/current"
-                // Restart the service (only has sudo permissions for this command)
-                sh "sudo systemctl restart dailygames"
-            }
-        }
     }
     post {
         success {

--- a/db/migrate.sh
+++ b/db/migrate.sh
@@ -5,9 +5,9 @@
 
 cd "$(dirname "$0")"
 
-username=$(find ~ -name "dailygames.env" -exec grep -m 1 "DB_USER" {} \; | cut -d '=' -f 2)
-password=$(find ~ -name "dailygames.env" -exec grep -m 1 "DB_PASSWORD" {} \; | cut -d '=' -f 2)
-db_name=$(find ~ -name "dailygames.env" -exec grep -m 1 "DB_NAME" {} \; | cut -d '=' -f 2)
+username=$DB_USER
+password=$DB_PASSWORD
+db_name=$DB_NAME
 
 liquibase updateSql --url=jdbc:postgresql://localhost:5432/"$db_name" --username="$username" --password="$password" || exit 1
 

--- a/db/migrate.sh
+++ b/db/migrate.sh
@@ -3,6 +3,8 @@
 # This script runs the Liquibase migrations in the db directory.
 # It uses the environment variables specified in the .env file to authenticate to the database.
 
+cd "$(dirname "$0")"
+
 username=$(find ~ -name "dailygames.env" -exec grep -m 1 "DB_USER" {} \; | cut -d '=' -f 2)
 password=$(find ~ -name "dailygames.env" -exec grep -m 1 "DB_PASSWORD" {} \; | cut -d '=' -f 2)
 db_name=$(find ~ -name "dailygames.env" -exec grep -m 1 "DB_NAME" {} \; | cut -d '=' -f 2)

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -3,14 +3,47 @@
 Runs as a systemd unit (see [dailygames.service](../dailygames.service)).
 
 Requires its own user. The systemd service file specifies a binary within that user's home
-directory, which is assembled by `./gradlew build` with the `application` Gradle plugin.
+directory, which is assembled by `./gradlew assemble` with the `application` Gradle plugin.
+
+## CI/CD Architecture
+
+Jenkins runs CI (build, lint, test) and sets a GitHub commit status.
+Deployment is handled separately by `scripts/deploy.sh`, triggered by systemd timers on the
+production server.
+
+## Environments
+
+- **`dailygames`** (production): deploys the latest commit on `origin/main`.
+- **`testdailygames`** (test): deploys the tip of whichever remote branch was most recently updated.
+
+Both wait for the target commit's CI status to be `success` before deploying.
+
+## Credentials
+
+Two credentials are required on the server, owned by the service user:
+
+| Credential       | Type            | Purpose                            | Location                      |
+|------------------|-----------------|------------------------------------|-------------------------------|
+| Deploy Key       | SSH private key | `git fetch` from GitHub            | `~/.ssh/deploy_key`           |
+| Fine-grained PAT | HTTP token      | Read commit status from GitHub API | `~/.github_token` (chmod 600) |
+
+The fine-grained PAT is scoped to `zwalsh/dailygames` with **Commit statuses: Read-only** permission.
+The deploy key is read-only.
 
 ## Dependencies
 
-Depends on a Postgres database server. Its schema is controlled by liquibase. See [db](../db) and
+Depends on a Postgres database server. Its schema is controlled by Liquibase. See [db](../db) and
 [liquibase.properties](../db/liquibase.properties). The database connection information (that
 isn't configured via environment variables) is configured in
 [hikari.properties](../src/main/resources/hikari.properties).
+
+The following must be present for the service users on the production host:
+
+- **JDK 17**
+- **Gradle wrapper** (`./gradlew` in the repo checkout — downloads Gradle automatically)
+- **Liquibase** on `$PATH`
+- **`jq`** (for parsing the GitHub API JSON response)
+- **`git`** on `$PATH`
 
 ## Environment
 
@@ -21,11 +54,29 @@ Requires a `dailygames.env` environment file in the user's home directory (loade
 |-------------------|----------------------------------------------------------------------------------------------|
 | ENV               | The name of the current environment. Controls header configuration, HTTPS usage, etc.        |
 | PORT              | The port that the server should start on.                                                    |
-| HOST              | The hostname at which the server is reachable.                                               | 
+| HOST              | The hostname at which the server is reachable.                                               |
 | WS_PROTOCOL       | `ws` or `wss` -- which protocol to use to connect to this server for a WebSocket connection. |
+| DB_NAME           | The name of the Postgres database to connect to.                                             |
 | DB_USER           | The user with which to connect to Postgres.                                                  |
 | DB_PASSWORD       | The password with which to connect to Postgres.                                              |
-| SENTRY_KOTLIN_DSN | The Sentry DSN to send Kotlin exceptions to.                                                 | 
+| SENTRY_KOTLIN_DSN | The Sentry DSN to send Kotlin exceptions to.                                                 |
 | SENTRY_JS_DSN     | The Sentry DSN to send Javascript exceptions to.                                             |
 | UMAMI_URL         | The URL of the Umami host to send analytics to.                                              |
 | UMAMI_WEBSITE_ID  | The website id of this deploy of Daily Games configured in Umami.                            |
+
+## Installing the timers
+
+Run as root on the production server from a checkout of the repo:
+
+```bash
+sudo bash scripts/install-timers.sh
+```
+
+To inspect timer status:
+
+```bash
+systemctl status dailygames-deploy.timer
+systemctl status testdailygames-deploy.timer
+journalctl -u dailygames-deploy.service -n 50
+journalctl -u testdailygames-deploy.service -n 50
+```

--- a/scripts/dailygames-deploy.service
+++ b/scripts/dailygames-deploy.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Daily Games deployment
+After=network.target
+
+[Service]
+Type=oneshot
+User=dailygames
+EnvironmentFile=/home/dailygames/dailygames.env
+ExecStart=/home/dailygames/dailygames/scripts/deploy.sh --env dailygames
+StandardOutput=journal
+StandardError=journal

--- a/scripts/dailygames-deploy.timer
+++ b/scripts/dailygames-deploy.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Daily Games deployment timer
+
+[Timer]
+OnBootSec=1min
+OnUnitActiveSec=1min
+Unit=dailygames-deploy.service
+
+[Install]
+WantedBy=timers.target

--- a/scripts/dailygames-deploy.timer
+++ b/scripts/dailygames-deploy.timer
@@ -3,7 +3,7 @@ Description=Daily Games deployment timer
 
 [Timer]
 OnBootSec=1min
-OnUnitActiveSec=1min
+OnUnitInactiveSec=1min
 Unit=dailygames-deploy.service
 
 [Install]

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -65,7 +65,11 @@ trap 'on_error $LINENO' ERR
 
 # 5. Check out the target commit
 log "[$ENV] Checking out $SHA"
-git -C "$REPO" checkout -f "$SHA"
+if [[ "$ENV" == "dailygames" ]]; then
+    git -C "$REPO" checkout -f main
+else
+    git -C "$REPO" -c advice.detachedHead=false checkout -f "$SHA"
+fi
 
 # 6. Build
 log "[$ENV] Building"
@@ -77,9 +81,13 @@ log "[$ENV] Unpacking to $RELEASE_DIR"
 mkdir -p "$RELEASE_DIR"
 tar -xf "$REPO/build/distributions/dailygames.tar" -C "$RELEASE_DIR"
 
-# 8. Run database migrations
-log "[$ENV] Running database migrations"
-"$REPO/db/migrate.sh"
+# 8. Run database migrations (testdailygames only migrates for commits on main)
+if [[ "$ENV" == "dailygames" ]] || git -C "$REPO" merge-base --is-ancestor "$SHA" origin/main; then
+    log "[$ENV] Running database migrations"
+    "$REPO/db/migrate.sh"
+else
+    log "[$ENV] Skipping database migrations: $SHA is not on main"
+fi
 
 # 9. Atomically update the current symlink
 log "[$ENV] Updating current symlink to $RELEASE_DIR"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+set -euo pipefail
+
+log() {
+    echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] $*"
+}
+
+ENV=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --env) ENV="$2"; shift 2 ;;
+        *) echo "Unknown argument: $1" >&2; exit 1 ;;
+    esac
+done
+
+if [[ "$ENV" != "dailygames" && "$ENV" != "testdailygames" ]]; then
+    echo "Usage: $0 --env <dailygames|testdailygames>" >&2
+    exit 1
+fi
+
+REPO=~/dailygames
+TOKEN=$(cat ~/.github_token)
+
+# 1. Fetch latest refs
+log "[$ENV] Fetching latest refs"
+git -C "$REPO" fetch origin
+
+# 2. Resolve target SHA
+if [[ "$ENV" == "dailygames" ]]; then
+    SHA=$(git -C "$REPO" rev-parse origin/main)
+else
+    SHA=$(git -C "$REPO" for-each-ref \
+        --sort=-committerdate \
+        --format='%(refname:short) %(objectname)' \
+        'refs/remotes/origin/*' | \
+        grep -v 'origin/HEAD' | \
+        awk 'NR==1{print $2}')
+fi
+log "[$ENV] Target SHA: $SHA"
+
+# 3. Exit if already deployed
+DEPLOYED_FILE=~/deployed_commit
+if [[ -f "$DEPLOYED_FILE" ]] && [[ "$(cat "$DEPLOYED_FILE")" == "$SHA" ]]; then
+    log "[$ENV] SHA $SHA already deployed, nothing to do"
+    exit 0
+fi
+
+# 4. Exit if CI status is not success
+STATUS=$(curl -s "https://api.github.com/repos/zwalsh/dailygames/commits/$SHA/status" \
+    -H "Authorization: token $TOKEN" | jq -r '.state // empty') || true
+log "[$ENV] CI status for $SHA: ${STATUS:-<empty>}"
+if [[ "$STATUS" != "success" ]]; then
+    log "[$ENV] CI not green (state=$STATUS), skipping deploy"
+    exit 0
+fi
+
+log "[$ENV] Starting deploy of $SHA"
+
+on_error() {
+    local exit_code=$?
+    local line=$1
+    log "[$ENV] DEPLOY FAILED at line $line (exit code $exit_code)"
+}
+trap 'on_error $LINENO' ERR
+
+# 5. Check out the target commit
+log "[$ENV] Checking out $SHA"
+git -C "$REPO" checkout -f "$SHA"
+
+# 6. Build
+log "[$ENV] Building"
+"$REPO/gradlew" -p "$REPO" assemble
+
+# 7. Unpack into release directory
+RELEASE_DIR=~/releases/$SHA
+log "[$ENV] Unpacking to $RELEASE_DIR"
+mkdir -p "$RELEASE_DIR"
+tar -xf "$REPO/build/distributions/dailygames.tar" -C "$RELEASE_DIR"
+
+# 8. Run database migrations
+log "[$ENV] Running database migrations"
+"$REPO/db/migrate.sh"
+
+# 9. Atomically update the current symlink
+log "[$ENV] Updating current symlink to $RELEASE_DIR"
+ln -sfn "$RELEASE_DIR" ~/releases/current
+
+# 10. Restart the service
+log "[$ENV] Restarting $ENV service"
+sudo systemctl restart "$ENV"
+
+# 11. Record the deployed commit
+echo "$SHA" > "$DEPLOYED_FILE"
+log "[$ENV] Deploy of $SHA complete"
+
+# 12. Prune old releases, keeping the 3 most recent
+log "[$ENV] Pruning old releases"
+ls -t ~/releases/ | grep -v '^current$' | tail -n +4 | xargs -I{} rm -rf ~/releases/{}

--- a/scripts/install-timers.sh
+++ b/scripts/install-timers.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+cp "$SCRIPT_DIR/dailygames-deploy.service" /etc/systemd/system/
+cp "$SCRIPT_DIR/dailygames-deploy.timer" /etc/systemd/system/
+cp "$SCRIPT_DIR/testdailygames-deploy.service" /etc/systemd/system/
+cp "$SCRIPT_DIR/testdailygames-deploy.timer" /etc/systemd/system/
+
+systemctl daemon-reload
+systemctl enable --now dailygames-deploy.timer
+systemctl enable --now testdailygames-deploy.timer
+
+echo "Timers installed and started."
+systemctl status dailygames-deploy.timer testdailygames-deploy.timer

--- a/scripts/testdailygames-deploy.service
+++ b/scripts/testdailygames-deploy.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Test Daily Games deployment
+After=network.target
+
+[Service]
+Type=oneshot
+User=testdailygames
+EnvironmentFile=/home/testdailygames/dailygames.env
+ExecStart=/home/testdailygames/dailygames/scripts/deploy.sh --env testdailygames
+StandardOutput=journal
+StandardError=journal

--- a/scripts/testdailygames-deploy.timer
+++ b/scripts/testdailygames-deploy.timer
@@ -3,7 +3,7 @@ Description=Test Daily Games deployment timer
 
 [Timer]
 OnBootSec=1min
-OnUnitActiveSec=1min
+OnUnitInactiveSec=1min
 Unit=testdailygames-deploy.service
 
 [Install]

--- a/scripts/testdailygames-deploy.timer
+++ b/scripts/testdailygames-deploy.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Test Daily Games deployment timer
+
+[Timer]
+OnBootSec=1min
+OnUnitActiveSec=1min
+Unit=testdailygames-deploy.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary

- **Jenkinsfile** stripped to pure CI (build, lint, test, set GitHub commit status) — all deploy/migrate/release stages removed
- **`scripts/deploy.sh`** added: polls GitHub status API, checks out target SHA, builds with Gradle, runs Liquibase migrations, atomically symlinks the release, restarts the systemd service, keeps last 3 releases; includes timestamped logging and an error trap
- **Four systemd unit files** (`dailygames-deploy.{service,timer}`, `testdailygames-deploy.{service,timer}`) fire `deploy.sh` every minute after the previous run finishes (`OnUnitInactiveSec`)
- **`scripts/install-timers.sh`** installs and enables all four units
- **`docs/deploy.md`** rewritten to describe the new CI/CD architecture, required credentials, and how to install/inspect the timers

## Test plan

- [ ] Jenkins CI passes on this branch (build/lint/test/status only — no deploy stages)
- [ ] After merge, run server setup steps from `docs/deploy.md` for both `dailygames` and `testdailygames` users
- [ ] Run `sudo bash scripts/install-timers.sh` on the production server
- [ ] Confirm `dailygames-deploy.timer` fires and deploys `origin/main` successfully
- [ ] Confirm `testdailygames-deploy.timer` fires and deploys the most-recently-updated branch
- [ ] Check logs: `journalctl -u dailygames-deploy.service -n 50`
- [ ] Remove legacy Jenkins sudo rules once both environments are confirmed working

🤖 Generated with [Claude Code](https://claude.com/claude-code)