### PR TITLE
Upgrade to Gradle 9.5.1

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{kt,kts}]
+ktlint_code_style = intellij_idea
+# Rules that changed behavior in ktlint 1.x (via plugin 12.x) vs 0.x (plugin 10.x).
+# Disabled to preserve existing code style during Gradle upgrade.
+ktlint_standard_trailing-comma-on-call-site = disabled
+ktlint_standard_trailing-comma-on-declaration-site = disabled
+ktlint_standard_discouraged-comment-location = disabled
+ktlint_standard_package-name = disabled
+ktlint_standard_no-empty-first-line-in-method-block = disabled
+ktlint_standard_argument-list-wrapping = disabled
+ktlint_standard_filename = disabled

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,13 +1,13 @@
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
-val kotlinVersion = "1.8.22" // keep in sync with plugin version
+val kotlinVersion = "2.1.21" // keep in sync with plugin version
 val ktorVersion = "2.2.4"
 val logbackVersion = "1.2.5"
 val jdbiVersion = "3.14.4"
 
 plugins {
-    kotlin("jvm") version "1.8.22"
-    id("org.jlleitschuh.gradle.ktlint") version "10.2.1"
+    kotlin("jvm") version "2.1.21"
+    id("org.jlleitschuh.gradle.ktlint") version "12.1.2"
     application
 }
 
@@ -98,9 +98,9 @@ application {
     mainClass.set("sh.zachwal.dailygames.AppKt")
 }
 
-tasks.withType(KotlinCompile::class.java).all {
-    kotlinOptions {
-        jvmTarget = "17"
+kotlin {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_17)
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/sh/zachwal/dailygames/App.kt
+++ b/src/main/kotlin/sh/zachwal/dailygames/App.kt
@@ -52,7 +52,6 @@ fun main(args: Array<String>): Unit = io.ktor.server.netty.EngineMain.main(args)
 @Suppress("unused") // Referenced in application.conf
 @kotlin.jvm.JvmOverloads
 fun Application.module(testing: Boolean = false) {
-
     val injector = Guice.createInjector(
         ApplicationModule(),
         ConfigModule(environment.config),
@@ -92,7 +91,7 @@ fun Application.module(testing: Boolean = false) {
     install(Sessions) {
         cookie<UserSessionPrincipal>(
             USER_SESSION,
-            storage = dbSessionStorage
+            storage = dbSessionStorage,
         ) {
             cookie.httpOnly = true
             cookie.secure = config.env != "DEV"

--- a/src/main/kotlin/sh/zachwal/dailygames/admin/AdminController.kt
+++ b/src/main/kotlin/sh/zachwal/dailygames/admin/AdminController.kt
@@ -64,7 +64,7 @@ class AdminController @Inject constructor(
                 }
 
                 u1.username.lowercase().compareTo(u2.username.lowercase())
-            }
+            },
         )
     }
 
@@ -90,7 +90,7 @@ class AdminController @Inject constructor(
                 val userRowViews = users.map {
                     UserRowView(
                         username = it.username,
-                        isAdmin = roles[it]?.contains(ADMIN) == true
+                        isAdmin = roles[it]?.contains(ADMIN) == true,
                     )
                 }
                 val currentUser = currentUser(call, userService)

--- a/src/main/kotlin/sh/zachwal/dailygames/admin/views/AdminPageView.kt
+++ b/src/main/kotlin/sh/zachwal/dailygames/admin/views/AdminPageView.kt
@@ -16,7 +16,7 @@ import sh.zachwal.dailygames.shared_html.darkMode
 import sh.zachwal.dailygames.shared_html.headSetup
 
 data class AdminPageView constructor(
-    private val navView: NavView
+    private val navView: NavView,
 ) : HTMLView<HTML>() {
     override fun HTML.render() {
         head {

--- a/src/main/kotlin/sh/zachwal/dailygames/admin/views/ResetUserPasswordView.kt
+++ b/src/main/kotlin/sh/zachwal/dailygames/admin/views/ResetUserPasswordView.kt
@@ -54,14 +54,14 @@ class ResetUserPasswordView(
                                     label { +"Username" }
                                     textInput(
                                         name = USERNAME_FORM_PARAM,
-                                        classes = "form-control"
+                                        classes = "form-control",
                                     )
                                 }
                                 div(classes = "mb-3") {
                                     label { +"New Password" }
                                     passwordInput(
                                         name = NEW_PASSWORD_FORM_PARAM,
-                                        classes = "form-control"
+                                        classes = "form-control",
                                     )
                                 }
                                 submitInput(classes = "btn btn-primary") {

--- a/src/main/kotlin/sh/zachwal/dailygames/admin/views/UserListView.kt
+++ b/src/main/kotlin/sh/zachwal/dailygames/admin/views/UserListView.kt
@@ -61,7 +61,7 @@ data class UserListView(
 
 data class UserRowView(
     private val username: String,
-    private val isAdmin: Boolean
+    private val isAdmin: Boolean,
 ) : HTMLView<TBODY>() {
     override fun TBODY.render() {
         tr {

--- a/src/main/kotlin/sh/zachwal/dailygames/answers/GameAnswerService.kt
+++ b/src/main/kotlin/sh/zachwal/dailygames/answers/GameAnswerService.kt
@@ -4,7 +4,7 @@ import sh.zachwal.dailygames.db.jdbi.puzzle.Game
 import sh.zachwal.dailygames.db.jdbi.puzzle.Puzzle
 
 abstract class GameAnswerService(
-    private val game: Game
+    private val game: Game,
 ) {
 
     fun answerForPuzzle(puzzle: Puzzle): String? {

--- a/src/main/kotlin/sh/zachwal/dailygames/chat/ChatController.kt
+++ b/src/main/kotlin/sh/zachwal/dailygames/chat/ChatController.kt
@@ -45,7 +45,7 @@ class ChatController @Inject constructor(
                 val chatView = chatViewService.chatView(
                     currentUser = currentUser,
                     game = game,
-                    puzzleNumber = puzzleNumber
+                    puzzleNumber = puzzleNumber,
                 )
 
                 call.respondHtml {

--- a/src/main/kotlin/sh/zachwal/dailygames/chat/ChatViewService.kt
+++ b/src/main/kotlin/sh/zachwal/dailygames/chat/ChatViewService.kt
@@ -75,7 +75,7 @@ class ChatViewService @Inject constructor(
         val navView = chatNav(
             username = currentUser.username,
             hasUserSubmittedResult = hasUserSubmittedResult,
-            puzzle = puzzle
+            puzzle = puzzle,
         )
 
         return ChatView(

--- a/src/main/kotlin/sh/zachwal/dailygames/chat/views/ChatSubmitFormView.kt
+++ b/src/main/kotlin/sh/zachwal/dailygames/chat/views/ChatSubmitFormView.kt
@@ -18,7 +18,7 @@ import sh.zachwal.dailygames.shared_html.view.SpinnerView
 data class ChatSubmitFormView(
     val game: Game,
     val puzzleNumber: Int,
-    val isCommentDisabled: Boolean
+    val isCommentDisabled: Boolean,
 ) : HTMLView<DIV>() {
     override fun DIV.render() {
         form(method = post, action = "${chatLink(game, puzzleNumber)}/comment") {

--- a/src/main/kotlin/sh/zachwal/dailygames/chat/views/ChatView.kt
+++ b/src/main/kotlin/sh/zachwal/dailygames/chat/views/ChatView.kt
@@ -49,7 +49,7 @@ data class ChatView constructor(
                         text = "",
                         timestampText = "",
                         instantSubmitted = Instant.now(),
-                        hidden = true
+                        hidden = true,
                     ).renderIn(this)
 
                     chatFeedItems.forEach {
@@ -62,7 +62,7 @@ data class ChatView constructor(
                             ChatSubmitFormView(
                                 game = game,
                                 puzzleNumber = puzzleNumber,
-                                isCommentDisabled = isCommentDisabled
+                                isCommentDisabled = isCommentDisabled,
                             ).renderIn(this)
                         }
                     }

--- a/src/main/kotlin/sh/zachwal/dailygames/config/AppConfig.kt
+++ b/src/main/kotlin/sh/zachwal/dailygames/config/AppConfig.kt
@@ -24,6 +24,6 @@ data class AppConfig(
         umamiConfig = UmamiConfig(
             umamiUrl = config.property("ktor.umami.url").getString(),
             websiteId = config.property("ktor.umami.websiteId").getString(),
-        )
+        ),
     )
 }

--- a/src/main/kotlin/sh/zachwal/dailygames/db/dao/ChatDAO.kt
+++ b/src/main/kotlin/sh/zachwal/dailygames/db/dao/ChatDAO.kt
@@ -14,13 +14,13 @@ interface ChatDAO {
             VALUES
             (:userId, :puzzle.game, :puzzle.number, now(), :text)
             RETURNING *
-        """
+        """,
     )
     fun insertChat(
         userId: Long,
         @BindBean("puzzle")
         puzzle: Puzzle,
-        text: String
+        text: String,
     ): Chat
 
     @SqlQuery(
@@ -30,11 +30,11 @@ interface ChatDAO {
             WHERE game = :puzzle.game 
             AND puzzle_number = :puzzle.number
             ORDER BY instant_submitted DESC
-        """
+        """,
     )
     fun chatsForPuzzleDescending(
         @BindBean("puzzle")
-        puzzle: Puzzle
+        puzzle: Puzzle,
     ): List<Chat>
 
     @SqlQuery(
@@ -43,7 +43,7 @@ interface ChatDAO {
             FROM chat
             WHERE instant_submitted > :instant
             ORDER BY instant_submitted
-        """
+        """,
     )
     fun allChatsSinceInstantAscending(instant: Instant): List<Chat>
 
@@ -53,10 +53,10 @@ interface ChatDAO {
             FROM chat
             WHERE game = :puzzle.game
             AND puzzle_number = :puzzle.number
-        """
+        """,
     )
     fun chatCountForPuzzle(
         @BindBean("puzzle")
-        puzzle: Puzzle
+        puzzle: Puzzle,
     ): Int
 }

--- a/src/main/kotlin/sh/zachwal/dailygames/db/dao/SessionDAO.kt
+++ b/src/main/kotlin/sh/zachwal/dailygames/db/dao/SessionDAO.kt
@@ -16,7 +16,7 @@ interface SessionDAO {
         """
         insert into public.session (id, data, expiration) values (:id, :data, :expiration)
         on conflict (id) do update set data = excluded.data, expiration = excluded.expiration
-    """
+    """,
     )
     fun createOrUpdateSession(@BindBean session: Session)
 

--- a/src/main/kotlin/sh/zachwal/dailygames/db/dao/UserDAO.kt
+++ b/src/main/kotlin/sh/zachwal/dailygames/db/dao/UserDAO.kt
@@ -23,7 +23,7 @@ interface UserDAO {
             UPDATE public.user
             SET hash = :newHash
             WHERE id = :userId
-        """
+        """,
     )
     fun updatePassword(userId: Long, newHash: String)
 }

--- a/src/main/kotlin/sh/zachwal/dailygames/db/dao/UserPreferencesDAO.kt
+++ b/src/main/kotlin/sh/zachwal/dailygames/db/dao/UserPreferencesDAO.kt
@@ -10,7 +10,7 @@ interface UserPreferencesDAO {
             INSERT INTO public.user_preferences (user_id)
             VALUES (:userId)
             RETURNING *
-        """
+        """,
     )
     fun createDefaultPreferences(userId: Long): UserPreferences
 
@@ -18,7 +18,7 @@ interface UserPreferencesDAO {
         """
             SELECT * FROM public.user_preferences
             WHERE user_id = :userId
-        """
+        """,
     )
     fun getByUserId(userId: Long): UserPreferences?
 
@@ -27,7 +27,7 @@ interface UserPreferencesDAO {
             UPDATE public.user_preferences
             SET time_zone = :timeZone
             WHERE user_id = :userId
-        """
+        """,
     )
     fun updateTimeZone(userId: Long, timeZone: String)
 }

--- a/src/main/kotlin/sh/zachwal/dailygames/db/dao/game/GameDAO.kt
+++ b/src/main/kotlin/sh/zachwal/dailygames/db/dao/game/GameDAO.kt
@@ -9,7 +9,7 @@ interface GameDAO {
     @SqlQuery(
         """
             SELECT name FROM game
-        """
+        """,
     )
     fun listGames(): List<Game>
 
@@ -17,7 +17,7 @@ interface GameDAO {
         """
             SELECT name FROM game
             WHERE instant_created > :instant
-        """
+        """,
     )
     fun listGamesCreatedAfter(instant: Instant): List<Game>
 }

--- a/src/main/kotlin/sh/zachwal/dailygames/db/dao/game/PuzzleDAO.kt
+++ b/src/main/kotlin/sh/zachwal/dailygames/db/dao/game/PuzzleDAO.kt
@@ -13,7 +13,7 @@ interface PuzzleDAO {
         INSERT INTO puzzle (game, number, date) 
         VALUES (:game, :number, :date)
         RETURNING *
-        """
+        """,
     )
     fun insertPuzzle(@BindBean puzzle: Puzzle): Puzzle
 
@@ -22,7 +22,7 @@ interface PuzzleDAO {
             SELECT game, number, date
             FROM puzzle
             WHERE game = :game AND number = :number
-        """
+        """,
     )
     fun getPuzzle(game: Game, number: Int): Puzzle?
 
@@ -32,7 +32,7 @@ interface PuzzleDAO {
             FROM puzzle
             WHERE game = :game
             ORDER BY number DESC
-        """
+        """,
     )
     fun listPuzzlesForGameDescending(game: Game): Stream<Puzzle>
 
@@ -43,7 +43,7 @@ interface PuzzleDAO {
                 FROM puzzle
                 WHERE game = :game AND number = :number
             )
-        """
+        """,
     )
     fun puzzleExists(game: Game, number: Int): Boolean
 
@@ -54,7 +54,7 @@ interface PuzzleDAO {
             WHERE game = :game AND number < :number
             ORDER BY number DESC
             LIMIT 1
-        """
+        """,
     )
     fun previousPuzzle(game: Game, number: Int): Puzzle?
 
@@ -65,7 +65,7 @@ interface PuzzleDAO {
             WHERE game = :game AND number > :number
             ORDER BY number ASC
             LIMIT 1
-        """
+        """,
     )
     fun nextPuzzle(game: Game, number: Int): Puzzle?
 
@@ -74,7 +74,7 @@ interface PuzzleDAO {
             SELECT game, max(number) AS number, max(date) AS date
             FROM puzzle
             GROUP BY game
-        """
+        """,
     )
     fun latestPuzzlePerGame(): List<Puzzle>
 }

--- a/src/main/kotlin/sh/zachwal/dailygames/db/dao/game/PuzzleResultDAO.kt
+++ b/src/main/kotlin/sh/zachwal/dailygames/db/dao/game/PuzzleResultDAO.kt
@@ -21,7 +21,7 @@ interface PuzzleResultDAO {
             VALUES
             (:userId, :puzzle.game, :puzzle.date, :puzzle.number, now(), :score, :shareText, :resultInfo)
             RETURNING *
-        """
+        """,
     )
     fun insertResult(
         userId: Long,
@@ -40,7 +40,7 @@ interface PuzzleResultDAO {
             VALUES
             (:userId, :puzzle.game, :puzzle.number, :instantSubmitted, :score, :shareText, :resultInfo)
             RETURNING *
-        """
+        """,
     )
     fun insertResultWithInstantSubmitted(
         userId: Long,
@@ -59,7 +59,7 @@ interface PuzzleResultDAO {
             FROM result
             WHERE puzzle_number = :puzzle.number
             AND game = :puzzle.game
-        """
+        """,
     )
     fun resultsForPuzzle(puzzle: Puzzle): List<PuzzleResult>
 
@@ -68,7 +68,7 @@ interface PuzzleResultDAO {
             SELECT * 
             FROM result
             ORDER BY instant_submitted DESC
-        """
+        """,
     )
     fun allResultsStream(): Stream<PuzzleResult>
 
@@ -79,7 +79,7 @@ interface PuzzleResultDAO {
             WHERE instant_submitted >= :start 
             AND instant_submitted < :end
             ORDER BY instant_submitted
-        """
+        """,
     )
     fun allResultsBetweenStream(start: Instant, end: Instant): Stream<PuzzleResult>
 
@@ -89,7 +89,7 @@ interface PuzzleResultDAO {
             FROM result
             WHERE game = :game
             ORDER BY instant_submitted DESC
-        """
+        """,
     )
     fun allResultsForGameStream(game: Game): Stream<PuzzleResult>
 
@@ -100,7 +100,7 @@ interface PuzzleResultDAO {
             WHERE user_id = :userId
             AND instant_submitted >= :start 
             AND instant_submitted < :end
-        """
+        """,
     )
     fun resultsForUserInTimeRange(userId: Long, start: Instant, end: Instant): List<PuzzleResult>
 
@@ -111,7 +111,7 @@ interface PuzzleResultDAO {
             WHERE user_id = :userId
             AND game = :puzzle.game
             AND puzzle_number = :puzzle.number
-        """
+        """,
     )
     fun findResults(userId: Long, puzzle: Puzzle): List<PuzzleResult>
 
@@ -121,7 +121,7 @@ interface PuzzleResultDAO {
             FROM result
             WHERE user_id = :userId
             ORDER BY instant_submitted DESC
-        """
+        """,
     )
     fun resultsForUserSortedStream(userId: Long): Stream<PuzzleResult>
 
@@ -133,7 +133,7 @@ interface PuzzleResultDAO {
             AND instant_submitted >= :since
             GROUP BY game
             ORDER BY count DESC
-        """
+        """,
     )
     @KeyColumn("game")
     @ValueColumn("count")

--- a/src/main/kotlin/sh/zachwal/dailygames/db/jdbi/Session.kt
+++ b/src/main/kotlin/sh/zachwal/dailygames/db/jdbi/Session.kt
@@ -16,7 +16,7 @@ import java.time.Instant
 data class Session(
     val id: String,
     val data: ByteArray,
-    val expiration: Instant
+    val expiration: Instant,
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/src/main/kotlin/sh/zachwal/dailygames/db/jdbi/User.kt
+++ b/src/main/kotlin/sh/zachwal/dailygames/db/jdbi/User.kt
@@ -6,5 +6,5 @@ data class User(
     val id: Long,
     val username: String,
     @ColumnName("hash")
-    val hashedPassword: String
+    val hashedPassword: String,
 )

--- a/src/main/kotlin/sh/zachwal/dailygames/db/jdbi/UserRole.kt
+++ b/src/main/kotlin/sh/zachwal/dailygames/db/jdbi/UserRole.kt
@@ -4,5 +4,5 @@ import sh.zachwal.dailygames.roles.Role
 
 data class UserRole(
     val userId: Long,
-    val role: Role
+    val role: Role,
 )

--- a/src/main/kotlin/sh/zachwal/dailygames/db/jdbi/puzzle/Game.kt
+++ b/src/main/kotlin/sh/zachwal/dailygames/db/jdbi/puzzle/Game.kt
@@ -13,7 +13,8 @@ enum class Game {
     FRAMED,
     GEOGRID,
     BANDLE,
-    BRACKET_CITY;
+    BRACKET_CITY,
+    ;
 
     fun displayName(): String {
         return when (this) {

--- a/src/main/kotlin/sh/zachwal/dailygames/features/ConfigureStatusPages.kt
+++ b/src/main/kotlin/sh/zachwal/dailygames/features/ConfigureStatusPages.kt
@@ -21,7 +21,6 @@ import sh.zachwal.dailygames.shared_html.headSetup
 private val logger = LoggerFactory.getLogger("StatusPage")
 
 fun StatusPagesConfig.configureStatusPages() {
-
     exception<Exception> { call, cause ->
         logger.error("Unhandled error", cause)
         call.respondHtml(HttpStatusCode.InternalServerError) {

--- a/src/main/kotlin/sh/zachwal/dailygames/guice/HikariModule.kt
+++ b/src/main/kotlin/sh/zachwal/dailygames/guice/HikariModule.kt
@@ -27,7 +27,7 @@ class HikariModule : AbstractModule() {
         appConfig.dbUserOverride?.let { override ->
             logger.info(
                 "Overriding configured db user with value from ktor.deployment" +
-                    ".db_user=$override"
+                    ".db_user=$override",
             )
             hikariConfig.dataSourceProperties.setProperty("user", override)
         } ?: run {

--- a/src/main/kotlin/sh/zachwal/dailygames/home/HomeService.kt
+++ b/src/main/kotlin/sh/zachwal/dailygames/home/HomeService.kt
@@ -26,7 +26,7 @@ import javax.inject.Singleton
 // Hide these games from the list
 val hiddenGames = setOf(
     // Pinpoint is not currently working & no one plays it anyway
-    Game.PINPOINT
+    Game.PINPOINT,
 )
 
 @Singleton
@@ -51,7 +51,7 @@ class HomeService @Inject constructor(
                         excludeUserId = 1, // Exclude my user in prod since I play the most
                     )
                 }
-            }
+            },
         )
 
     fun homeView(user: User): HomeView {

--- a/src/main/kotlin/sh/zachwal/dailygames/home/ShareLineMapper.kt
+++ b/src/main/kotlin/sh/zachwal/dailygames/home/ShareLineMapper.kt
@@ -13,7 +13,7 @@ import javax.inject.Singleton
 
 @Singleton
 class ShareLineMapper @Inject constructor(
-    private val pointCalculator: PointCalculator
+    private val pointCalculator: PointCalculator,
 ) {
 
     fun mapToShareLine(result: PuzzleResult): String {
@@ -22,7 +22,8 @@ class ShareLineMapper @Inject constructor(
             Game.TRADLE,
             Game.FRAMED,
             Game.PINPOINT,
-            Game.BANDLE -> result.toStandardShareLine()
+            Game.BANDLE,
+            -> result.toStandardShareLine()
 
             Game.GEOCIRCLES -> result.toGeocirclesShareLine()
             Game.TOP5 -> result.toTop5ShareLine()

--- a/src/main/kotlin/sh/zachwal/dailygames/home/views/HomeView.kt
+++ b/src/main/kotlin/sh/zachwal/dailygames/home/views/HomeView.kt
@@ -26,7 +26,7 @@ data class HomeView(
 ) : HTMLView<HTML>() {
 
     private val gameSubmitFormView = GameSubmitFormView(
-        includeShareButton = shareTextModalView != null
+        includeShareButton = shareTextModalView != null,
     )
 
     override fun HTML.render() {

--- a/src/main/kotlin/sh/zachwal/dailygames/home/views/gamelinks/GameListView.kt
+++ b/src/main/kotlin/sh/zachwal/dailygames/home/views/gamelinks/GameListView.kt
@@ -5,7 +5,7 @@ import kotlinx.html.div
 import sh.zachwal.dailygames.shared_html.HTMLView
 
 data class GameListView(
-    val games: List<GameLinkView>
+    val games: List<GameLinkView>,
 ) : HTMLView<DIV>() {
     override fun DIV.render() {
         div(classes = "row overflow-auto flex-nowrap py-3 my-1") {

--- a/src/main/kotlin/sh/zachwal/dailygames/leaderboard/LeaderboardService.kt
+++ b/src/main/kotlin/sh/zachwal/dailygames/leaderboard/LeaderboardService.kt
@@ -48,7 +48,8 @@ class LeaderboardService @Inject constructor(
             Game.TRADLE,
             Game.FLAGLE,
             Game.FRAMED,
-            Game.BANDLE -> BasicScoreHintView("Scoring: 1 point for the correct answer, 1 point per guess left. e.g. 2/6 = 5 points.")
+            Game.BANDLE,
+            -> BasicScoreHintView("Scoring: 1 point for the correct answer, 1 point per guess left. e.g. 2/6 = 5 points.")
 
             Game.PINPOINT -> BasicScoreHintView("Scoring: 1 point for the correct answer, 1 point per guess left. e.g. 2/5 = 4 points.")
             Game.GEOGRID -> BasicScoreHintView("Scoring: 1 point per correct guess. e.g. 8/9 = 8 points.")
@@ -88,7 +89,7 @@ class LeaderboardService @Inject constructor(
     }
 
     private fun leaderboardData(
-        pointsData: PointsData
+        pointsData: PointsData,
     ) = LeaderboardData(
         allTimePoints = chartInfo(pointsData.allTimePerUser) { it.totalPoints.toDouble() },
         allTimeGames = chartInfo(pointsData.allTimePerUser) { it.games.toDouble() },
@@ -191,7 +192,7 @@ data class PointsData constructor(
             allTimePerUser
                 .getOrDefault(userId, TotalPoints(0, 0))
                 .addPerformance(
-                    other.allTimePerUser.getOrDefault(userId, TotalPoints(0, 0))
+                    other.allTimePerUser.getOrDefault(userId, TotalPoints(0, 0)),
                 )
         }
         val newThirtyDays = (thirtyDaysPerUser.keys + other.thirtyDaysPerUser.keys).associateWith { userId ->

--- a/src/main/kotlin/sh/zachwal/dailygames/leaderboard/PointCalculator.kt
+++ b/src/main/kotlin/sh/zachwal/dailygames/leaderboard/PointCalculator.kt
@@ -18,11 +18,13 @@ class PointCalculator {
             Game.FLAGLE,
             Game.PINPOINT,
             Game.FRAMED,
-            Game.BANDLE -> maxPoints(result) + 1 - score
+            Game.BANDLE,
+            -> maxPoints(result) + 1 - score
 
             Game.TOP5,
             Game.GEOCIRCLES,
-            Game.GEOGRID -> score
+            Game.GEOGRID,
+            -> score
 
             Game.TRAVLE -> (result.info<TravleInfo>()).calculatePoints(score)
 
@@ -37,13 +39,15 @@ class PointCalculator {
             Game.TRADLE,
             Game.FLAGLE,
             Game.FRAMED,
-            Game.BANDLE -> 6
+            Game.BANDLE,
+            -> 6
 
             Game.PINPOINT -> 5
 
             Game.TOP5,
             Game.GEOCIRCLES,
-            Game.BRACKET_CITY -> 10
+            Game.BRACKET_CITY,
+            -> 10
 
             Game.TRAVLE -> (result.info<TravleInfo>()).maxPoints(score)
 

--- a/src/main/kotlin/sh/zachwal/dailygames/leaderboard/responses/ChartInfo.kt
+++ b/src/main/kotlin/sh/zachwal/dailygames/leaderboard/responses/ChartInfo.kt
@@ -2,5 +2,5 @@ package sh.zachwal.dailygames.leaderboard.responses
 
 data class ChartInfo(
     val labels: List<String>,
-    val dataPoints: List<Double>
+    val dataPoints: List<Double>,
 )

--- a/src/main/kotlin/sh/zachwal/dailygames/leaderboard/views/LeaderboardView.kt
+++ b/src/main/kotlin/sh/zachwal/dailygames/leaderboard/views/LeaderboardView.kt
@@ -42,7 +42,7 @@ data class LeaderboardView(
                     scoringText = """
                         Overall performance across all games. 
                         See individual leaderboards for scoring information.
-                    """.trimIndent()
+                    """.trimIndent(),
                 ).renderIn(this)
                 SectionHeaderView("All Time").renderIn(this)
                 div(classes = "row") {

--- a/src/main/kotlin/sh/zachwal/dailygames/leaderboard/views/ScoreHintView.kt
+++ b/src/main/kotlin/sh/zachwal/dailygames/leaderboard/views/ScoreHintView.kt
@@ -11,7 +11,7 @@ import sh.zachwal.dailygames.shared_html.HTMLView
 sealed class ScoreHintView : HTMLView<DIV>()
 
 data class BasicScoreHintView(
-    val scoringText: String
+    val scoringText: String,
 ) : ScoreHintView() {
     override fun DIV.render() {
         div(classes = "row") {

--- a/src/main/kotlin/sh/zachwal/dailygames/nav/ChatNavItemView.kt
+++ b/src/main/kotlin/sh/zachwal/dailygames/nav/ChatNavItemView.kt
@@ -40,7 +40,7 @@ data class ChatNavItemView(
                     li {
                         a(
                             href = "/game/${game.name.lowercase()}/puzzle",
-                            classes = "dropdown-item d-flex justify-content-between align-items-center"
+                            classes = "dropdown-item d-flex justify-content-between align-items-center",
                         ) {
                             +"${game.emoji()} ${game.displayName()}"
                             if (gameChatTotal > 0) {

--- a/src/main/kotlin/sh/zachwal/dailygames/nav/LeaderboardNavItemView.kt
+++ b/src/main/kotlin/sh/zachwal/dailygames/nav/LeaderboardNavItemView.kt
@@ -9,7 +9,7 @@ import sh.zachwal.dailygames.db.jdbi.puzzle.Game
 import sh.zachwal.dailygames.shared_html.HTMLView
 
 data class LeaderboardNavItemView(
-    val isActive: Boolean
+    val isActive: Boolean,
 ) : HTMLView<UL>() {
 
     private val textStyling = if (isActive) {

--- a/src/main/kotlin/sh/zachwal/dailygames/nav/NavItemView.kt
+++ b/src/main/kotlin/sh/zachwal/dailygames/nav/NavItemView.kt
@@ -10,7 +10,7 @@ data class NavItemView(
     val href: String,
     val icon: String,
     val text: String,
-    val isActive: Boolean
+    val isActive: Boolean,
 ) : HTMLView<UL>() {
 
     private val textStyling = if (isActive) {

--- a/src/main/kotlin/sh/zachwal/dailygames/nav/NavView.kt
+++ b/src/main/kotlin/sh/zachwal/dailygames/nav/NavView.kt
@@ -18,7 +18,7 @@ enum class NavItem {
 
 data class NavView constructor(
     val navItems: List<HTMLView<UL>>,
-    val insideNavItem: HTMLView<HEADER>? = null
+    val insideNavItem: HTMLView<HEADER>? = null,
 ) : HTMLView<BODY>() {
 
     constructor(
@@ -31,7 +31,7 @@ data class NavView constructor(
                 href = "/",
                 icon = "bi-house-door-fill",
                 isActive = currentActiveNavItem == NavItem.HOME,
-                text = "Home"
+                text = "Home",
             ),
             ChatNavItemView(
                 isActive = currentActiveNavItem == NavItem.CHAT,
@@ -44,10 +44,10 @@ data class NavView constructor(
                 href = "/profile",
                 icon = "bi-person-circle",
                 isActive = currentActiveNavItem == NavItem.PROFILE,
-                text = "Profile"
-            )
+                text = "Profile",
+            ),
         ),
-        insideNavItem
+        insideNavItem,
     )
 
     override fun BODY.render() {

--- a/src/main/kotlin/sh/zachwal/dailygames/nav/NavViewFactory.kt
+++ b/src/main/kotlin/sh/zachwal/dailygames/nav/NavViewFactory.kt
@@ -8,13 +8,13 @@ import javax.inject.Singleton
 
 @Singleton
 class NavViewFactory @Inject constructor(
-    private val chatService: ChatService
+    private val chatService: ChatService,
 ) {
 
     fun navView(
         username: String,
         currentActiveNavItem: NavItem,
-        insideNavItem: HTMLView<HEADER>? = null
+        insideNavItem: HTMLView<HEADER>? = null,
     ): NavView {
         val currentChatCounts = chatService.currentChatCounts()
 

--- a/src/main/kotlin/sh/zachwal/dailygames/results/ResultService.kt
+++ b/src/main/kotlin/sh/zachwal/dailygames/results/ResultService.kt
@@ -44,7 +44,7 @@ class ResultService @Inject constructor(
 
     fun createResult(
         user: User,
-        shareText: String
+        shareText: String,
     ): PuzzleResult {
         // regex & parse share text
         val game = shareTextParser.identifyGame(shareText) ?: run {
@@ -66,7 +66,9 @@ class ResultService @Inject constructor(
             ).also {
                 logger.info(
                     "User {} submitted result for {} #{}",
-                    user.username, it.game.displayName(), it.puzzleNumber
+                    user.username,
+                    it.game.displayName(),
+                    it.puzzleNumber,
                 )
             }
         } catch (e: UnableToExecuteStatementException) {
@@ -76,7 +78,7 @@ class ResultService @Inject constructor(
             } else {
                 logger.error(
                     "Error inserting result for ${game.displayName()} #${parsedResult.puzzleNumber} for user ${user.username}",
-                    e
+                    e,
                 )
                 throw e
             }

--- a/src/main/kotlin/sh/zachwal/dailygames/results/ShareTextParser.kt
+++ b/src/main/kotlin/sh/zachwal/dailygames/results/ShareTextParser.kt
@@ -38,7 +38,7 @@ class ShareTextParser {
     }
 
     val worldleRegex = Regex(
-        """\s*#Worldle\s+#(?<puzzleNumber>\d+)\s+\((?<day>\d{2})\.(?<month>\d{2})\.(?<year>\d{4})\)\s+(?<score>\S)/6\s+\((?<percentage>\d+)%\)[\s\S]*"""
+        """\s*#Worldle\s+#(?<puzzleNumber>\d+)\s+\((?<day>\d{2})\.(?<month>\d{2})\.(?<year>\d{4})\)\s+(?<score>\S)/6\s+\((?<percentage>\d+)%\)[\s\S]*""",
     )
 
     fun extractWorldleInfo(shareText: String): ParsedResult {
@@ -53,14 +53,14 @@ class ShareTextParser {
             date = LocalDate.of(year.toInt(), month.toInt(), day.toInt()),
             score = score.toIntOrNull() ?: 7, // X / 6 scored as 7 points
             shareTextNoLink = shareText.substringBefore("https://").trim(),
-            resultInfo = worldleInfo
+            resultInfo = worldleInfo,
         )
     }
 
     val tradleRegex = Regex(
         """
             \s*#Tradle\s+#(?<puzzleNumber>\d+)\s+(?<score>\S)/6[\s\S]*
-        """.trimIndent()
+        """.trimIndent(),
     )
 
     fun extractTradleInfo(shareText: String): ParsedResult {
@@ -73,7 +73,7 @@ class ShareTextParser {
             date = null,
             score = score.toIntOrNull() ?: 7, // X / 6 scored as 7 points.
             shareTextNoLink = shareText.substringBefore("https://").trim(),
-            resultInfo = tradleInfo
+            resultInfo = tradleInfo,
         )
     }
 
@@ -112,14 +112,14 @@ class ShareTextParser {
             date = null,
             score = score,
             shareTextNoLink = shareText.substringBefore("https://").trim(),
-            resultInfo = travleInfo
+            resultInfo = travleInfo,
         )
     }
 
     val top5Regex = Regex(
         """
             \s*Top 5\s+#(?<puzzleNumber>\d+)[\s\S]*
-        """.trimIndent()
+        """.trimIndent(),
     )
     val perfectTop5Regex = Regex("\uD83D\uDFE5\uD83D\uDFE7\uD83D\uDFE8\uD83D\uDFE9\uD83D\uDFE6")
     val top5GuessRegex = Regex("[\uD83D\uDFE5\uD83D\uDFE7\uD83D\uDFE8\uD83D\uDFE9\uD83D\uDFE6⬜]")
@@ -137,7 +137,7 @@ class ShareTextParser {
         val top5Info = Top5Info(
             numGuesses = numGuesses,
             numCorrect = numCorrect,
-            isPerfect = isPerfect
+            isPerfect = isPerfect,
         )
         return ParsedResult(
             puzzleNumber = puzzleNumber.toInt(),
@@ -145,14 +145,14 @@ class ShareTextParser {
             date = null,
             score = score,
             shareTextNoLink = shareText.substringBefore("https://").trim(),
-            resultInfo = top5Info
+            resultInfo = top5Info,
         )
     }
 
     val flagleRegex = Regex(
         """
             \s*#Flagle\s+#(?<puzzleNumber>\d+)\s+\((?<day>\d{2})\.(?<month>\d{2})\.(?<year>\d{4})\)\s+(?<score>\S)/6\s+[\s\S]*
-        """.trimIndent()
+        """.trimIndent(),
     )
 
     fun extractFlagleInfo(shareText: String): ParsedResult {
@@ -171,7 +171,7 @@ class ShareTextParser {
     val pinpointRegex = Regex(
         """
             \s*Pinpoint #(?<puzzleNumber>\d+)[\s\S]*\((?<score>\S)/5\)[\s\S]*
-        """.trimIndent()
+        """.trimIndent(),
     )
 
     fun extractPinpointInfo(shareText: String): ParsedResult {
@@ -191,7 +191,7 @@ class ShareTextParser {
     val geocirclesRegex = Regex(
         """
             \s*Geocircles #(?<puzzleNumber>\d+)[\s\S]*
-        """.trimIndent()
+        """.trimIndent(),
     )
     val greenCircleOrHeartRegex = Regex("(\uD83D\uDFE2|❤\uFE0F)")
     fun extractGeocirclesInfo(shareText: String): ParsedResult {
@@ -205,14 +205,14 @@ class ShareTextParser {
             date = null,
             score = score,
             shareTextNoLink = shareText.substringBefore("https://").trim(),
-            resultInfo = GeocirclesInfo
+            resultInfo = GeocirclesInfo,
         )
     }
 
     val framedRegex = Regex(
         """
             \s*Framed #(?<puzzleNumber>\d+)[\s\S]*
-        """.trimIndent()
+        """.trimIndent(),
     )
     val redSquareRegex = Regex("\uD83D\uDFE5")
     fun extractFramedInfo(shareText: String): ParsedResult {
@@ -226,7 +226,7 @@ class ShareTextParser {
             date = null,
             score = score,
             shareTextNoLink = shareText.substringBefore("https://").trim(),
-            resultInfo = FramedInfo
+            resultInfo = FramedInfo,
         )
     }
 
@@ -273,8 +273,8 @@ class ShareTextParser {
                 score = score,
                 rank = rank,
                 rankOutOf = rankOutOf,
-                numCorrect = numCorrect
-            )
+                numCorrect = numCorrect,
+            ),
         )
     }
 
@@ -306,7 +306,7 @@ class ShareTextParser {
                 numSkips = skipRegex.findAll(shareText).count(),
                 numCorrectBand = correctBandRegex.findAll(shareText).count(),
                 numIncorrect = incorrectRegex.findAll(shareText).count(),
-            )
+            ),
         )
     }
 
@@ -348,7 +348,7 @@ class ShareTextParser {
             peeks = peeks,
             answersRevealed = answersRevealed,
             totalScore = totalScore,
-            grid = grid
+            grid = grid,
         )
 
         return ParsedResult(

--- a/src/main/kotlin/sh/zachwal/dailygames/results/resultinfo/BracketCityInfo.kt
+++ b/src/main/kotlin/sh/zachwal/dailygames/results/resultinfo/BracketCityInfo.kt
@@ -7,5 +7,5 @@ data class BracketCityInfo(
     val peeks: Int = 0,
     val answersRevealed: Int = 0,
     val totalScore: Double,
-    val grid: String
+    val grid: String,
 ) : ResultInfo()

--- a/src/main/kotlin/sh/zachwal/dailygames/roles/RoleAuthorization.kt
+++ b/src/main/kotlin/sh/zachwal/dailygames/roles/RoleAuthorization.kt
@@ -29,7 +29,7 @@ class RoleAuthorization internal constructor(config: Configuration) {
     class RoleBasedAuthorizer {
         internal lateinit var authorizationFunction: suspend ApplicationCall.(
             Set<Role>,
-            UserSessionPrincipal
+            UserSessionPrincipal,
         ) -> Role?
 
         fun validate(body: suspend ApplicationCall.(Set<Role>, UserSessionPrincipal) -> Role?) {
@@ -73,7 +73,7 @@ class RoleAuthorization internal constructor(config: Configuration) {
 
         override fun install(
             pipeline: ApplicationCallPipeline,
-            configure: RoleBasedAuthorizer.() -> Unit
+            configure: RoleBasedAuthorizer.() -> Unit,
         ): RoleAuthorization {
             val configuration = RoleBasedAuthorizer().apply(configure)
             return RoleAuthorization(configuration)

--- a/src/main/kotlin/sh/zachwal/dailygames/session/principals/SessionPrincipal.kt
+++ b/src/main/kotlin/sh/zachwal/dailygames/session/principals/SessionPrincipal.kt
@@ -19,7 +19,7 @@ interface SessionPrincipal {
             this,
             expiration,
             curEpochMilli,
-            expiration > curEpochMilli
+            expiration > curEpochMilli,
         )
         return expiration > curEpochMilli
     }

--- a/src/main/kotlin/sh/zachwal/dailygames/session/principals/UserSessionPrincipal.kt
+++ b/src/main/kotlin/sh/zachwal/dailygames/session/principals/UserSessionPrincipal.kt
@@ -4,5 +4,5 @@ import io.ktor.server.auth.Principal
 
 data class UserSessionPrincipal constructor(
     val user: String,
-    override val expiration: Long
+    override val expiration: Long,
 ) : Principal, SessionPrincipal

--- a/src/main/kotlin/sh/zachwal/dailygames/shared_html/Head.kt
+++ b/src/main/kotlin/sh/zachwal/dailygames/shared_html/Head.kt
@@ -13,12 +13,12 @@ fun HEAD.bootstrapCss() {
     link(
         rel = "stylesheet",
         href = "https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css",
-        type = "text/css"
+        type = "text/css",
     )
     link(
         rel = "stylesheet",
         href = "https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css",
-        type = "text/css"
+        type = "text/css",
     )
 }
 
@@ -26,13 +26,13 @@ fun HEAD.commonCss() {
     link(
         rel = "stylesheet",
         href = "/static/src/css/common.css",
-        type = "text/css"
+        type = "text/css",
     )
 }
 
 fun HEAD.bootstrapJs() {
     script(
-        src = "https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
+        src = "https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js",
     ) {
         integrity = "sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"
         attributes["crossorigin"] = "anonymous"

--- a/src/main/kotlin/sh/zachwal/dailygames/users/UserController.kt
+++ b/src/main/kotlin/sh/zachwal/dailygames/users/UserController.kt
@@ -71,7 +71,7 @@ class UserController @Inject constructor(
                     val p = call.principal<UserIdPrincipal>()
                         ?: return@post call.respond(
                             HttpStatusCode.InternalServerError,
-                            "No User principal found after post"
+                            "No User principal found after post",
                         )
                     sessionService.createUserSession(call, p.name)
                     call.respondRedirect("/")
@@ -86,7 +86,7 @@ class UserController @Inject constructor(
         "Hi",
         "Howdy",
         "Salutations",
-        "What's good"
+        "What's good",
     ).random()
 
     internal fun Routing.profileRoute() {
@@ -114,7 +114,7 @@ class UserController @Inject constructor(
                         timeZoneFormView = timeZoneFormView,
                         navView = navViewFactory.navView(
                             user.username,
-                            currentActiveNavItem = NavItem.PROFILE
+                            currentActiveNavItem = NavItem.PROFILE,
                         ),
                     )
 
@@ -150,7 +150,7 @@ class UserController @Inject constructor(
                     params["username"]
                         ?: throw IllegalArgumentException("Missing required parameter: username"),
                     params["password"]
-                        ?: throw IllegalArgumentException("Missing required parameter: password")
+                        ?: throw IllegalArgumentException("Missing required parameter: password"),
                 )
 
                 if (user != null) {

--- a/src/main/kotlin/sh/zachwal/dailygames/users/UserPreferencesService.kt
+++ b/src/main/kotlin/sh/zachwal/dailygames/users/UserPreferencesService.kt
@@ -12,7 +12,7 @@ import javax.inject.Singleton
 
 @Singleton
 class UserPreferencesService @Inject constructor(
-    private val userPreferencesDAO: UserPreferencesDAO
+    private val userPreferencesDAO: UserPreferencesDAO,
 ) {
 
     fun getTimeZone(userId: Long): ZoneId {

--- a/src/main/kotlin/sh/zachwal/dailygames/users/UserService.kt
+++ b/src/main/kotlin/sh/zachwal/dailygames/users/UserService.kt
@@ -86,7 +86,7 @@ class UserService @Inject constructor(
         user: User,
         currentPassword: String,
         newPassword: String,
-        repeatNewPassword: String
+        repeatNewPassword: String,
     ): ChangePasswordResult {
         if (newPassword != repeatNewPassword) {
             return ChangePasswordFailure("Passwords do not match")

--- a/src/main/kotlin/sh/zachwal/dailygames/users/views/ChangePasswordView.kt
+++ b/src/main/kotlin/sh/zachwal/dailygames/users/views/ChangePasswordView.kt
@@ -19,7 +19,7 @@ import sh.zachwal.dailygames.users.NEW_PASSWORD_FORM_PARAM
 import sh.zachwal.dailygames.users.REPEAT_NEW_PASSWORD_FORM_PARAM
 
 class ChangePasswordView(
-    val errorMessage: String? = null
+    val errorMessage: String? = null,
 ) : HTMLView<HTML>() {
     override fun HTML.render() {
         head {
@@ -45,21 +45,21 @@ class ChangePasswordView(
                                     label { +"Current Password" }
                                     passwordInput(
                                         name = CURRENT_PASSWORD_FORM_PARAM,
-                                        classes = "form-control"
+                                        classes = "form-control",
                                     )
                                 }
                                 div(classes = "mb-3") {
                                     label { +"New Password" }
                                     passwordInput(
                                         name = NEW_PASSWORD_FORM_PARAM,
-                                        classes = "form-control"
+                                        classes = "form-control",
                                     )
                                 }
                                 div(classes = "mb-3") {
                                     label { +"Repeat New Password" }
                                     passwordInput(
                                         name = REPEAT_NEW_PASSWORD_FORM_PARAM,
-                                        classes = "form-control"
+                                        classes = "form-control",
                                     )
                                 }
                                 submitInput(classes = "btn btn-primary") {

--- a/src/main/kotlin/sh/zachwal/dailygames/users/views/LoginView.kt
+++ b/src/main/kotlin/sh/zachwal/dailygames/users/views/LoginView.kt
@@ -36,7 +36,7 @@ data class LoginView(private val failed: Boolean) : HTMLView<HTML>() {
                                     label { +"Username" }
                                     textInput(
                                         name = "username",
-                                        classes = "form-control"
+                                        classes = "form-control",
                                     ) {
                                         placeholder = "user"
                                     }
@@ -45,7 +45,7 @@ data class LoginView(private val failed: Boolean) : HTMLView<HTML>() {
                                     label { +"Password" }
                                     passwordInput(
                                         name = "password",
-                                        classes = "form-control"
+                                        classes = "form-control",
                                     ) {
                                         placeholder = "password"
                                     }

--- a/src/main/kotlin/sh/zachwal/dailygames/users/views/RegisterView.kt
+++ b/src/main/kotlin/sh/zachwal/dailygames/users/views/RegisterView.kt
@@ -35,7 +35,7 @@ object RegisterView : HTMLView<HTML>() {
                                     label { +"Username" }
                                     textInput(
                                         name = "username",
-                                        classes = "form-control"
+                                        classes = "form-control",
                                     ) {
                                         placeholder = "user"
                                     }
@@ -44,7 +44,7 @@ object RegisterView : HTMLView<HTML>() {
                                     label { +"Password" }
                                     passwordInput(
                                         name = "password",
-                                        classes = "form-control"
+                                        classes = "form-control",
                                     ) {
                                         placeholder = "password"
                                     }

--- a/src/main/kotlin/sh/zachwal/dailygames/users/views/TimeZoneFormView.kt
+++ b/src/main/kotlin/sh/zachwal/dailygames/users/views/TimeZoneFormView.kt
@@ -20,7 +20,6 @@ class TimeZoneFormView(
     val timeZonesToNames: Map<ZoneId, String>,
 ) : HTMLView<DIV>() {
     override fun DIV.render() {
-
         card(cardHeader = "Set Time Zone", cardHeaderClasses = "text-center") {
             form(method = post, action = POST_TIME_ZONE_ROUTE) {
                 div(classes = "mb-3") {

--- a/src/main/kotlin/sh/zachwal/dailygames/wrapped/WrappedController.kt
+++ b/src/main/kotlin/sh/zachwal/dailygames/wrapped/WrappedController.kt
@@ -19,7 +19,6 @@ class WrappedController @Inject constructor(
 ) {
 
     internal fun Routing.wrapped() {
-
         adminRoute("/wrapped/{year}/as/{userName}") {
             get {
                 val year = (

--- a/src/main/kotlin/sh/zachwal/dailygames/wrapped/WrappedService.kt
+++ b/src/main/kotlin/sh/zachwal/dailygames/wrapped/WrappedService.kt
@@ -89,7 +89,7 @@ class WrappedService @Inject constructor(
                 SummaryTableSection(wrappedInfo, wrappedIndex++),
                 buildRanksTableTotals(wrappedInfo, wrappedIndex++),
                 buildRanksTableAverages(wrappedInfo, wrappedIndex),
-            )
+            ),
         )
     }
 
@@ -108,32 +108,32 @@ class WrappedService @Inject constructor(
                 WelcomeSection(
                     year,
                     userName,
-                    wrappedIndex++
+                    wrappedIndex++,
                 ),
                 StatSection(
                     topText = "You played...",
                     stat = wrappedInfo.totalGamesPlayed,
                     bottomText = "...games this year.",
-                    wrappedIndex++
+                    wrappedIndex++,
                 ),
                 StatSection(
                     topText = "That ranks...",
                     stat = wrappedInfo.totalGamesRank,
                     bottomText = "...across all players!",
-                    wrappedIndex++
+                    wrappedIndex++,
                 ),
                 // points scored
                 StatSection(
                     topText = "You scored...",
                     stat = wrappedInfo.totalPoints,
                     bottomText = "...points this year.",
-                    wrappedIndex++
+                    wrappedIndex++,
                 ),
                 StatSection(
                     topText = "That ranks...",
                     stat = wrappedInfo.totalPointsRank,
                     bottomText = "...overall!",
-                    wrappedIndex++
+                    wrappedIndex++,
                 ),
                 wrappedInfo.favoriteGame.let {
                     val favoriteGameText = "${it.emoji()}${it.displayName()}${it.emoji()}"
@@ -142,7 +142,7 @@ class WrappedService @Inject constructor(
                         topText = "Your favorite game was...",
                         middleText = favoriteGameText,
                         bottomText = "...you played it $favoriteGamePlayCount times!",
-                        wrappedIndex = wrappedIndex++
+                        wrappedIndex = wrappedIndex++,
                     )
                 },
                 wrappedInfo.bestDay?.let {
@@ -150,20 +150,20 @@ class WrappedService @Inject constructor(
                         topText = "Your best day was...",
                         middleText = it.format(bestDayFormatter),
                         bottomText = "...when you scored ${wrappedInfo.bestDayPoints} points!",
-                        wrappedIndex = wrappedIndex++
+                        wrappedIndex = wrappedIndex++,
                     )
                 },
                 StatSection(
                     topText = "You played Daily Games for...",
                     stat = wrappedInfo.totalMinutes,
                     bottomText = "...minutes this year.",
-                    wrappedIndex = wrappedIndex++
+                    wrappedIndex = wrappedIndex++,
                 ),
                 StatSection(
                     topText = "That's number...",
                     stat = wrappedInfo.totalMinutesRank,
                     bottomText = "... of all players!",
-                    wrappedIndex = wrappedIndex++
+                    wrappedIndex = wrappedIndex++,
                 ),
                 wrappedInfo.bestGame?.let {
                     val bestGameText = "${it.emoji()}${it.displayName()}${it.emoji()}"
@@ -171,7 +171,7 @@ class WrappedService @Inject constructor(
                         topText = "Your best game was...",
                         middleText = bestGameText,
                         bottomText = "",
-                        wrappedIndex = wrappedIndex++
+                        wrappedIndex = wrappedIndex++,
                     )
                 },
                 wrappedInfo.bestGame?.let {
@@ -182,7 +182,7 @@ class WrappedService @Inject constructor(
                         middleText = bestGameAverage.toString(),
                         bottomText = "...which ranks #$bestGameRank!",
                         fontSizeOverride = "35vw;",
-                        wrappedIndex = wrappedIndex++
+                        wrappedIndex = wrappedIndex++,
                     )
                 },
                 wrappedInfo.longestStreakGame?.let {
@@ -190,7 +190,7 @@ class WrappedService @Inject constructor(
                         topText = "Your longest streak was...",
                         stat = wrappedInfo.longestStreak,
                         bottomText = "...you played ${it.displayName()} ${wrappedInfo.longestStreak} days in a row!",
-                        wrappedIndex = wrappedIndex++
+                        wrappedIndex = wrappedIndex++,
                     )
                 },
                 SummaryTableSection(
@@ -203,7 +203,7 @@ class WrappedService @Inject constructor(
             wrappedShareView = WrappedShareView(
                 year = year,
                 username = userName,
-            )
+            ),
         )
     }
 
@@ -261,7 +261,7 @@ class WrappedService @Inject constructor(
             .toInstant()
         val allResults = resultDAO.allResultsBetweenStream(
             start = yearStartInstant,
-            end = yearEndInstant
+            end = yearEndInstant,
         )
 
         val userIds = mutableSetOf<Long>()
@@ -298,7 +298,7 @@ class WrappedService @Inject constructor(
                 .merge(
                     it.instantSubmitted.atZone(timeZone).toLocalDate(),
                     calculator.calculatePoints(it),
-                    Int::plus
+                    Int::plus,
                 )
         }.peek {
             val timeZone = userPreferencesService.getTimeZoneCached(it.userId)

--- a/src/test/kotlin/sh/zachwal/dailygames/answers/FlagleAnswerServiceTest.kt
+++ b/src/test/kotlin/sh/zachwal/dailygames/answers/FlagleAnswerServiceTest.kt
@@ -63,7 +63,7 @@ class FlagleAnswerServiceTest {
             java.net.http.HttpRequest.newBuilder()
                 .uri(java.net.URI.create(url))
                 .build(),
-            java.net.http.HttpResponse.BodyHandlers.ofString()
+            java.net.http.HttpResponse.BodyHandlers.ofString(),
         )
 
         return if (response.statusCode() == 200) {

--- a/src/test/kotlin/sh/zachwal/dailygames/chat/ChatServiceTest.kt
+++ b/src/test/kotlin/sh/zachwal/dailygames/chat/ChatServiceTest.kt
@@ -94,7 +94,7 @@ class ChatServiceTest {
                 Game.TRADLE to 2,
                 Game.TOP5 to 7,
                 Game.TRAVLE to 9,
-            )
+            ),
         )
     }
 }

--- a/src/test/kotlin/sh/zachwal/dailygames/chat/ChatViewServiceTest.kt
+++ b/src/test/kotlin/sh/zachwal/dailygames/chat/ChatViewServiceTest.kt
@@ -103,7 +103,7 @@ class ChatViewServiceTest {
         every { puzzleDAO.listPuzzlesForGameDescending(Game.WORLDLE) } returns Stream.of(
             Puzzle(Game.WORLDLE, 3, null),
             Puzzle(Game.WORLDLE, 2, null),
-            Puzzle(Game.WORLDLE, 1, null)
+            Puzzle(Game.WORLDLE, 1, null),
         )
         every { resultService.allResultsForPuzzle(any()) } returns emptyList()
 
@@ -124,7 +124,7 @@ class ChatViewServiceTest {
         shareText = "",
         resultInfo = WorldleInfo(
             percentage = 100,
-        )
+        ),
     )
 
     @Test
@@ -321,7 +321,7 @@ class ChatViewServiceTest {
         val answer = "answer"
         every { answerService.answerForPuzzle(Puzzle(Game.WORLDLE, 123, null)) } returns answer
         every { resultService.allResultsForPuzzle(Puzzle(Game.WORLDLE, 123, null)) } returns listOf(
-            worldleResult.copy(userId = zach.id)
+            worldleResult.copy(userId = zach.id),
         )
 
         val chatView = chatService.chatView(zach, Game.WORLDLE, 123)
@@ -335,7 +335,7 @@ class ChatViewServiceTest {
         val answer = "answer"
         every { answerService.answerForPuzzle(Puzzle(Game.WORLDLE, 123, null)) } returns answer
         every { resultService.allResultsForPuzzle(Puzzle(Game.WORLDLE, 123, null)) } returns listOf(
-            worldleResult.copy(userId = testUser.id)
+            worldleResult.copy(userId = testUser.id),
         )
 
         val chatView = chatService.chatView(testUser, Game.WORLDLE, 123)
@@ -360,7 +360,7 @@ class ChatViewServiceTest {
     fun `hides AnswerView when no answer is returned`() {
         every { answerService.answerForPuzzle(Puzzle(Game.WORLDLE, 123, null)) } returns null
         every { resultService.allResultsForPuzzle(Puzzle(Game.WORLDLE, 123, null)) } returns listOf(
-            worldleResult.copy(userId = zach.id)
+            worldleResult.copy(userId = zach.id),
         )
 
         val chatView = chatService.chatView(zach, Game.WORLDLE, 123)

--- a/src/test/kotlin/sh/zachwal/dailygames/db/dao/UserDAOTest.kt
+++ b/src/test/kotlin/sh/zachwal/dailygames/db/dao/UserDAOTest.kt
@@ -9,9 +9,8 @@ import org.junit.jupiter.api.extension.ExtendWith
 import sh.zachwal.dailygames.db.extension.DatabaseExtension
 
 @ExtendWith(DatabaseExtension::class)
-
 class UserDAOTest(
-    private val jdbi: Jdbi
+    private val jdbi: Jdbi,
 ) {
     private val userDAO: UserDAO = jdbi.onDemand()
 

--- a/src/test/kotlin/sh/zachwal/dailygames/db/dao/game/GameDAOTest.kt
+++ b/src/test/kotlin/sh/zachwal/dailygames/db/dao/game/GameDAOTest.kt
@@ -12,7 +12,7 @@ import java.time.temporal.ChronoUnit
 
 @ExtendWith(DatabaseExtension::class)
 class GameDAOTest(
-    private val jdbi: Jdbi
+    private val jdbi: Jdbi,
 ) {
 
     private val dao = jdbi.onDemand<GameDAO>()
@@ -27,7 +27,7 @@ class GameDAOTest(
     @Test
     fun `listGamesCreatedAfter returns empty for date in the future`() {
         val games = dao.listGamesCreatedAfter(
-            Instant.now().plusSeconds(10)
+            Instant.now().plusSeconds(10),
         )
 
         assertThat(games).isEmpty()
@@ -37,7 +37,7 @@ class GameDAOTest(
     fun `listGamesCreatedAfter returns games created 4 days ago`() {
         // migration in test creates games with instant_created of 3 days ago
         val games = dao.listGamesCreatedAfter(
-            Instant.now().minus(4, ChronoUnit.DAYS)
+            Instant.now().minus(4, ChronoUnit.DAYS),
         )
 
         assertThat(games).containsExactlyElementsIn(Game.values())
@@ -52,7 +52,7 @@ class GameDAOTest(
                     UPDATE game 
                     SET instant_created = now() 
                     WHERE name = 'WORLDLE';
-                """.trimIndent()
+                """.trimIndent(),
             )
         }
 

--- a/src/test/kotlin/sh/zachwal/dailygames/db/dao/game/PuzzleResultDAOTest.kt
+++ b/src/test/kotlin/sh/zachwal/dailygames/db/dao/game/PuzzleResultDAOTest.kt
@@ -24,7 +24,7 @@ import kotlin.streams.toList
 @ExtendWith(DatabaseExtension::class)
 class PuzzleResultDAOTest(
     jdbi: Jdbi,
-    private val fixtures: Fixtures
+    private val fixtures: Fixtures,
 ) {
 
     private val resultDAO: PuzzleResultDAO = jdbi.onDemand()
@@ -40,7 +40,7 @@ class PuzzleResultDAOTest(
             puzzle = fixtures.worldle123Puzzle,
             score = 3,
             shareText = "Worldle #123 2.11.2024 3/6",
-            resultInfo = expectedWorldleInfo
+            resultInfo = expectedWorldleInfo,
         )
 
         assertThat(result.userId).isEqualTo(fixtures.zach.id)

--- a/src/test/kotlin/sh/zachwal/dailygames/db/extension/DailyGamesPostgresContainer.kt
+++ b/src/test/kotlin/sh/zachwal/dailygames/db/extension/DailyGamesPostgresContainer.kt
@@ -11,7 +11,7 @@ class DailyGamesPostgresContainer :
         return DriverManager.getConnection(
             jdbcUrl,
             USERNAME,
-            PASSWORD
+            PASSWORD,
         )
     }
 }

--- a/src/test/kotlin/sh/zachwal/dailygames/db/extension/DatabaseExtension.kt
+++ b/src/test/kotlin/sh/zachwal/dailygames/db/extension/DatabaseExtension.kt
@@ -52,7 +52,7 @@ class DatabaseExtension : ParameterResolver, BeforeEachCallback, AfterEachCallba
             .getOrComputeIfAbsent(
                 POSTGRES_CONTAINER_KEY,
                 { createPostgresContainer() },
-                DailyGamesPostgresContainer::class.java
+                DailyGamesPostgresContainer::class.java,
             )
     }
 
@@ -74,7 +74,7 @@ class DatabaseExtension : ParameterResolver, BeforeEachCallback, AfterEachCallba
         val liquibase = Liquibase(
             "changelog.json",
             DirectoryResourceAccessor(Path("db")),
-            database
+            database,
         )
 
         liquibase.dropAll()
@@ -118,7 +118,7 @@ class DatabaseExtension : ParameterResolver, BeforeEachCallback, AfterEachCallba
             .getOrComputeIfAbsent(
                 JDBI_KEY,
                 { createJdbiInstance(context) },
-                Jdbi::class.java
+                Jdbi::class.java,
             )
     }
 
@@ -142,7 +142,7 @@ class DatabaseExtension : ParameterResolver, BeforeEachCallback, AfterEachCallba
             .getOrComputeIfAbsent(
                 FIXTURES_KEY,
                 { createFixturesInstance(context) },
-                Fixtures::class.java
+                Fixtures::class.java,
             )
     }
 

--- a/src/test/kotlin/sh/zachwal/dailygames/db/extension/Fixtures.kt
+++ b/src/test/kotlin/sh/zachwal/dailygames/db/extension/Fixtures.kt
@@ -10,7 +10,7 @@ import sh.zachwal.dailygames.db.jdbi.puzzle.Game
 import sh.zachwal.dailygames.db.jdbi.puzzle.Puzzle
 
 class Fixtures(
-    jdbi: Jdbi
+    jdbi: Jdbi,
 ) {
     private val userDAO: UserDAO = jdbi.onDemand()
 

--- a/src/test/kotlin/sh/zachwal/dailygames/db/jdbi/puzzle/PuzzleResultTest.kt
+++ b/src/test/kotlin/sh/zachwal/dailygames/db/jdbi/puzzle/PuzzleResultTest.kt
@@ -19,7 +19,7 @@ class PuzzleResultTest {
         score = 5,
         shareText = "",
         resultInfo = WorldleInfo(
-            percentage = 100
+            percentage = 100,
         ),
     )
 

--- a/src/test/kotlin/sh/zachwal/dailygames/home/HomeServiceTest.kt
+++ b/src/test/kotlin/sh/zachwal/dailygames/home/HomeServiceTest.kt
@@ -26,7 +26,7 @@ class HomeServiceTest {
     private val userPreferencesService = mockk<UserPreferencesService> {
         every { getTimeZone(any()) } returns ZoneId.of("America/New_York")
     }
-    private val shareTextService = mockk<ShareTextService>() {
+    private val shareTextService = mockk<ShareTextService> {
         every { shareTextModalView(any()) } returns null
     }
     private val navViewFactory = mockk<NavViewFactory> {

--- a/src/test/kotlin/sh/zachwal/dailygames/home/ShareLineMapperTest.kt
+++ b/src/test/kotlin/sh/zachwal/dailygames/home/ShareLineMapperTest.kt
@@ -27,7 +27,7 @@ import java.time.LocalDate
 class ShareLineMapperTest {
 
     private val mapper = ShareLineMapper(
-        pointCalculator = PointCalculator()
+        pointCalculator = PointCalculator(),
     )
     private val parser = ShareTextParser()
 
@@ -116,7 +116,7 @@ class ShareLineMapperTest {
     private val flagleResult = worldleResult.copy(
         game = Game.FLAGLE,
         score = 1,
-        resultInfo = FlagleInfo
+        resultInfo = FlagleInfo,
     )
 
     @Test
@@ -155,7 +155,7 @@ class ShareLineMapperTest {
     fun `maps travle plus zero non-perfect`() {
         val result = travleResult.copy(
             score = 0,
-            resultInfo = (travleResult.info<TravleInfo>()).copy(numPerfect = 5)
+            resultInfo = (travleResult.info<TravleInfo>()).copy(numPerfect = 5),
         )
 
         val shareLine = mapper.mapToShareLine(result)
@@ -171,7 +171,7 @@ class ShareLineMapperTest {
                 numGuesses = 7,
                 numPerfect = 6,
                 numIncorrect = 1,
-            )
+            ),
         )
 
         val shareLine = mapper.mapToShareLine(result)
@@ -188,7 +188,7 @@ class ShareLineMapperTest {
                 numPerfect = 6,
                 numIncorrect = 1,
                 numHints = 2,
-            )
+            ),
         )
 
         val shareLine = mapper.mapToShareLine(result)
@@ -204,7 +204,7 @@ class ShareLineMapperTest {
                 numGuesses = 10,
                 numPerfect = 6,
                 numIncorrect = 4,
-            )
+            ),
         )
 
         val shareLine = mapper.mapToShareLine(result)
@@ -221,7 +221,7 @@ class ShareLineMapperTest {
                 numPerfect = 6,
                 numIncorrect = 4,
                 numHints = 1,
-            )
+            ),
         )
 
         val shareLine = mapper.mapToShareLine(result)
@@ -236,7 +236,7 @@ class ShareLineMapperTest {
             numGuesses = 5,
             numCorrect = 5,
             isPerfect = true,
-        )
+        ),
     )
 
     @Test
@@ -250,8 +250,8 @@ class ShareLineMapperTest {
     fun `maps top5 five correct, no misses, but not perfect`() {
         val result = top5Result.copy(
             resultInfo = (top5Result.info<Top5Info>()).copy(
-                isPerfect = false
-            )
+                isPerfect = false,
+            ),
         )
 
         val shareLine = mapper.mapToShareLine(result)
@@ -266,7 +266,7 @@ class ShareLineMapperTest {
                 numCorrect = 5,
                 numGuesses = 6,
                 isPerfect = false,
-            )
+            ),
         )
 
         val shareLine = mapper.mapToShareLine(result)
@@ -281,7 +281,7 @@ class ShareLineMapperTest {
                 numCorrect = 4,
                 numGuesses = 10,
                 isPerfect = false,
-            )
+            ),
         )
 
         val shareLine = mapper.mapToShareLine(result)
@@ -413,7 +413,7 @@ class ShareLineMapperTest {
             resultInfo = geoGridResult.info<GeoGridInfo>().copy(
                 numCorrect = 0,
                 score = 900.0,
-            )
+            ),
         )
 
         val shareLine = mapper.mapToShareLine(result)
@@ -427,7 +427,7 @@ class ShareLineMapperTest {
             resultInfo = geoGridResult.info<GeoGridInfo>().copy(
                 numCorrect = 8,
                 score = 200.5,
-            )
+            ),
         )
 
         val shareLine = mapper.mapToShareLine(result)
@@ -439,7 +439,7 @@ class ShareLineMapperTest {
         val result = geoGridResult.copy(
             resultInfo = geoGridResult.info<GeoGridInfo>().copy(
                 score = 200.55,
-            )
+            ),
         )
 
         val shareLine = mapper.mapToShareLine(result)
@@ -482,7 +482,7 @@ class ShareLineMapperTest {
         val result = bracketCityResult.copy(
             score = 98,
             shareText = BRACKET_CITY_POWER_BROKER,
-            resultInfo = parser.extractBracketCityInfo(BRACKET_CITY_POWER_BROKER).info()
+            resultInfo = parser.extractBracketCityInfo(BRACKET_CITY_POWER_BROKER).info(),
         )
         val shareLine = mapper.mapToShareLine(result)
         assertThat(shareLine).isEqualTo("🏙️ Bracket City 4/20 98.0 \uD83D\uDCBC")
@@ -493,7 +493,7 @@ class ShareLineMapperTest {
         val result = bracketCityResult.copy(
             score = 69,
             shareText = BRACKET_CITY_CHIEF_OF_POLICE,
-            resultInfo = parser.extractBracketCityInfo(BRACKET_CITY_CHIEF_OF_POLICE).info()
+            resultInfo = parser.extractBracketCityInfo(BRACKET_CITY_CHIEF_OF_POLICE).info(),
         )
         val shareLine = mapper.mapToShareLine(result)
         assertThat(shareLine).isEqualTo("🏙️ Bracket City 4/20 69.0 \uD83D\uDC6E")
@@ -504,7 +504,7 @@ class ShareLineMapperTest {
         val result = bracketCityResult.copy(
             score = 100,
             shareText = BRACKET_CITY_KINGMAKER,
-            resultInfo = parser.extractBracketCityInfo(BRACKET_CITY_KINGMAKER).info()
+            resultInfo = parser.extractBracketCityInfo(BRACKET_CITY_KINGMAKER).info(),
         )
         val shareLine = mapper.mapToShareLine(result)
         assertThat(shareLine).isEqualTo("🏙️ Bracket City 4/20 100.0 \uD83D\uDC51")
@@ -515,7 +515,7 @@ class ShareLineMapperTest {
         val result = bracketCityResult.copy(
             score = 0,
             shareText = BRACKET_CITY_TOURIST,
-            resultInfo = parser.extractBracketCityInfo(BRACKET_CITY_TOURIST).info()
+            resultInfo = parser.extractBracketCityInfo(BRACKET_CITY_TOURIST).info(),
         )
         val shareLine = mapper.mapToShareLine(result)
         assertThat(shareLine).isEqualTo("🏙️ Bracket City 4/20 0.0 \uD83D\uDCF8")
@@ -526,7 +526,7 @@ class ShareLineMapperTest {
         val result = bracketCityResult.copy(
             score = 100,
             shareText = BRACKET_CITY_PUPPETMASTER,
-            resultInfo = parser.extractBracketCityInfo(BRACKET_CITY_PUPPETMASTER).info()
+            resultInfo = parser.extractBracketCityInfo(BRACKET_CITY_PUPPETMASTER).info(),
         )
         val shareLine = mapper.mapToShareLine(result)
         assertThat(shareLine).isEqualTo("🏙️ Bracket City 4/20 100.0 \uD83D\uDD2E")

--- a/src/test/kotlin/sh/zachwal/dailygames/home/ShareTextServiceTest.kt
+++ b/src/test/kotlin/sh/zachwal/dailygames/home/ShareTextServiceTest.kt
@@ -16,7 +16,7 @@ import java.time.Instant
 class ShareTextServiceTest {
     private val user = User(id = 1L, username = "zach", hashedPassword = "123abc==")
     private val shareLineMapper = ShareLineMapper(
-        pointCalculator = PointCalculator()
+        pointCalculator = PointCalculator(),
     )
     private val streakService = mockk<StreakService> {
         every { streakForUser(any()) } returns 3
@@ -49,7 +49,7 @@ class ShareTextServiceTest {
             numIncorrect = 2,
             numPerfect = 3,
             numHints = 1,
-        )
+        ),
     )
     private val resultService = mockk<ResultService> {
         every { resultsForUserToday(user) } returns listOf(worldleResult, travleResult)

--- a/src/test/kotlin/sh/zachwal/dailygames/leaderboard/LeaderboardServiceTest.kt
+++ b/src/test/kotlin/sh/zachwal/dailygames/leaderboard/LeaderboardServiceTest.kt
@@ -75,7 +75,7 @@ class LeaderboardServiceTest {
             numGuesses = 5,
             numCorrect = 0,
             isPerfect = false,
-        )
+        ),
     )
 
     @Test
@@ -85,7 +85,7 @@ class LeaderboardServiceTest {
         verify {
             navViewFactory.navView(
                 username = testUser.username,
-                currentActiveNavItem = NavItem.LEADERBOARD
+                currentActiveNavItem = NavItem.LEADERBOARD,
             )
         }
     }
@@ -101,7 +101,7 @@ class LeaderboardServiceTest {
     fun `gameLeaderboardData returns user's average all time`() {
         every { resultDAO.allResultsForGameStream(Game.TOP5) } returns Stream.of(
             result.copy(score = 5),
-            result.copy(score = 4)
+            result.copy(score = 4),
         )
 
         val leaderboardData = leaderboardService.gameLeaderboardData(Game.TOP5)
@@ -114,7 +114,7 @@ class LeaderboardServiceTest {
     fun `gameLeaderboardData returns user's total points`() {
         every { resultDAO.allResultsForGameStream(Game.TOP5) } returns Stream.of(
             result.copy(score = 5),
-            result.copy(score = 4)
+            result.copy(score = 4),
         )
 
         val leaderboardData = leaderboardService.gameLeaderboardData(Game.TOP5)
@@ -127,7 +127,7 @@ class LeaderboardServiceTest {
     fun `gameLeaderboardData returns user's total games played`() {
         every { resultDAO.allResultsForGameStream(Game.TOP5) } returns Stream.of(
             result.copy(score = 5),
-            result.copy(score = 4)
+            result.copy(score = 4),
         )
 
         val leaderboardData = leaderboardService.gameLeaderboardData(Game.TOP5)
@@ -140,7 +140,7 @@ class LeaderboardServiceTest {
     fun `gameLeaderboardData filters to user's last thirty days`() {
         every { resultDAO.allResultsForGameStream(Game.TOP5) } returns Stream.of(
             result.copy(score = 5, instantSubmitted = Instant.now()),
-            result.copy(score = 4, instantSubmitted = Instant.now().minus(31, ChronoUnit.DAYS))
+            result.copy(score = 4, instantSubmitted = Instant.now().minus(31, ChronoUnit.DAYS)),
         )
 
         val leaderboardData = leaderboardService.gameLeaderboardData(Game.TOP5)
@@ -154,7 +154,7 @@ class LeaderboardServiceTest {
         every { resultDAO.allResultsForGameStream(Game.TOP5) } returns Stream.of(
             result.copy(score = 5, instantSubmitted = Instant.now()),
             result.copy(score = 6, instantSubmitted = Instant.now()),
-            result.copy(score = 4, instantSubmitted = Instant.now().minus(31, ChronoUnit.DAYS))
+            result.copy(score = 4, instantSubmitted = Instant.now().minus(31, ChronoUnit.DAYS)),
         )
 
         val leaderboardData = leaderboardService.gameLeaderboardData(Game.TOP5)
@@ -168,7 +168,7 @@ class LeaderboardServiceTest {
         every { resultDAO.allResultsForGameStream(Game.TOP5) } returns Stream.of(
             result.copy(score = 5, instantSubmitted = Instant.now()),
             result.copy(score = 6, instantSubmitted = Instant.now()),
-            result.copy(score = 4, instantSubmitted = Instant.now().minus(31, ChronoUnit.DAYS))
+            result.copy(score = 4, instantSubmitted = Instant.now().minus(31, ChronoUnit.DAYS)),
         )
 
         val leaderboardData = leaderboardService.gameLeaderboardData(Game.TOP5)
@@ -190,11 +190,11 @@ class LeaderboardServiceTest {
             shareText = "",
             resultInfo = WorldleInfo(
                 percentage = 100,
-            )
+            ),
         )
         every { resultDAO.allResultsForGameStream(Game.TOP5) } returns Stream.empty()
         every { resultDAO.allResultsForGameStream(Game.WORLDLE) } returns Stream.of(
-            worldleResult
+            worldleResult,
         )
 
         val leaderboardData = leaderboardService.gameLeaderboardData(Game.WORLDLE)
@@ -213,7 +213,7 @@ class LeaderboardServiceTest {
             result.copy(userId = derekUser.id, score = 9),
             result.copy(userId = jackieUser.id, score = 8),
             result.copy(userId = chatGPTUser.id, score = 7),
-            result.copy(userId = mikMapUser.id, score = 6)
+            result.copy(userId = mikMapUser.id, score = 6),
         )
 
         val leaderboardData = leaderboardService.gameLeaderboardData(Game.TOP5)
@@ -223,7 +223,7 @@ class LeaderboardServiceTest {
             derekUser.username,
             jackieUser.username,
             chatGPTUser.username,
-            mikMapUser.username
+            mikMapUser.username,
         )
         assertThat(leaderboardData.allTimeAverage.labels).doesNotContain(zachUser.username)
     }
@@ -239,18 +239,18 @@ class LeaderboardServiceTest {
         shareText = "",
         resultInfo = WorldleInfo(
             percentage = 100,
-        )
+        ),
     )
 
     @Test
     fun `overall leaderboardData averages user's points across all games`() {
         every { resultDAO.allResultsForGameStream(Game.TOP5) } returns Stream.of(
             result.copy(score = 5),
-            result.copy(score = 4)
+            result.copy(score = 4),
         )
         every { resultDAO.allResultsForGameStream(Game.WORLDLE) } returns Stream.of(
             worldleResult.copy(score = 2), // 5 points
-            worldleResult.copy(score = 1) // 6 points
+            worldleResult.copy(score = 1), // 6 points
         )
 
         val leaderboardData = leaderboardService.overallLeaderboardData()
@@ -263,11 +263,11 @@ class LeaderboardServiceTest {
     fun `overall leaderboardData sums user's points across all games`() {
         every { resultDAO.allResultsForGameStream(Game.TOP5) } returns Stream.of(
             result.copy(score = 5),
-            result.copy(score = 4)
+            result.copy(score = 4),
         )
         every { resultDAO.allResultsForGameStream(Game.WORLDLE) } returns Stream.of(
             worldleResult.copy(score = 2), // 5 points
-            worldleResult.copy(score = 1) // 6 points
+            worldleResult.copy(score = 1), // 6 points
         )
 
         val leaderboardData = leaderboardService.overallLeaderboardData()
@@ -280,11 +280,11 @@ class LeaderboardServiceTest {
     fun `overall leaderboardData sums user's games played`() {
         every { resultDAO.allResultsForGameStream(Game.TOP5) } returns Stream.of(
             result.copy(score = 5),
-            result.copy(score = 4)
+            result.copy(score = 4),
         )
         every { resultDAO.allResultsForGameStream(Game.WORLDLE) } returns Stream.of(
             worldleResult.copy(score = 2), // 5 points
-            worldleResult.copy(score = 1) // 6 points
+            worldleResult.copy(score = 1), // 6 points
         )
 
         val leaderboardData = leaderboardService.overallLeaderboardData()
@@ -297,18 +297,18 @@ class LeaderboardServiceTest {
     fun `overall leaderboardData includes multiple users`() {
         every { resultDAO.allResultsForGameStream(Game.TOP5) } returns Stream.of(
             result.copy(userId = derekUser.id, score = 5),
-            result.copy(userId = jackieUser.id, score = 4)
+            result.copy(userId = jackieUser.id, score = 4),
         )
         every { resultDAO.allResultsForGameStream(Game.WORLDLE) } returns Stream.of(
             worldleResult.copy(userId = derekUser.id, score = 2), // 5 points
-            worldleResult.copy(userId = jackieUser.id, score = 3) // 4 points
+            worldleResult.copy(userId = jackieUser.id, score = 3), // 4 points
         )
 
         val leaderboardData = leaderboardService.overallLeaderboardData()
 
         assertThat(leaderboardData.allTimeAverage.labels).containsExactly(
             derekUser.username,
-            jackieUser.username
+            jackieUser.username,
         )
         assertThat(leaderboardData.allTimeAverage.dataPoints).containsExactly(5.0, 4.0)
     }
@@ -318,18 +318,18 @@ class LeaderboardServiceTest {
         every { resultDAO.allResultsForGameStream(Game.TOP5) } returns Stream.of(
             result.copy(score = 5, instantSubmitted = Instant.now()),
             result.copy(
-                score = 4, instantSubmitted = Instant.now().minus(31, ChronoUnit.DAYS)
-            )
+                score = 4, instantSubmitted = Instant.now().minus(31, ChronoUnit.DAYS),
+            ),
         )
         every { resultDAO.allResultsForGameStream(Game.WORLDLE) } returns Stream.of(
             worldleResult.copy(
                 score = 2, // 5 points
-                instantSubmitted = Instant.now()
+                instantSubmitted = Instant.now(),
             ),
             worldleResult.copy(
                 score = 3, // 4 points
-                instantSubmitted = Instant.now().minus(31, ChronoUnit.DAYS)
-            )
+                instantSubmitted = Instant.now().minus(31, ChronoUnit.DAYS),
+            ),
         )
 
         val leaderboardData = leaderboardService.overallLeaderboardData()
@@ -414,7 +414,7 @@ class LeaderboardServiceTest {
     fun `dailyLeaderboardData aggregates multiple results for one user`() {
         every { resultDAO.allResultsBetweenStream(any(), any()) } returns Stream.of(
             result.copy(userId = testUser.id, score = 5),
-            result.copy(userId = testUser.id, score = 10)
+            result.copy(userId = testUser.id, score = 10),
         )
         every { userService.getUsernameCached(testUser.id) } returns testUser.username
 
@@ -432,7 +432,7 @@ class LeaderboardServiceTest {
             result.copy(userId = jackieUser.id, score = 8),
             result.copy(userId = chatGPTUser.id, score = 7),
             result.copy(userId = mikMapUser.id, score = 6),
-            result.copy(userId = zachUser.id, score = 5)
+            result.copy(userId = zachUser.id, score = 5),
         )
         every { userService.getUsernameCached(testUser.id) } returns testUser.username
         every { userService.getUsernameCached(derekUser.id) } returns derekUser.username
@@ -448,7 +448,7 @@ class LeaderboardServiceTest {
             derekUser.username,
             jackieUser.username,
             chatGPTUser.username,
-            mikMapUser.username
+            mikMapUser.username,
         )
         assertThat(chartInfo.dataPoints).containsExactly(10.0, 9.0, 8.0, 7.0, 6.0)
     }
@@ -461,7 +461,7 @@ class LeaderboardServiceTest {
             result.copy(userId = jackieUser.id, score = 8),
             result.copy(userId = chatGPTUser.id, score = 7),
             result.copy(userId = mikMapUser.id, score = 6),
-            result.copy(userId = zachUser.id, score = 5)
+            result.copy(userId = zachUser.id, score = 5),
         )
         every { userService.getUsernameCached(testUser.id) } returns testUser.username
         every { userService.getUsernameCached(derekUser.id) } returns derekUser.username
@@ -477,7 +477,7 @@ class LeaderboardServiceTest {
             derekUser.username,
             jackieUser.username,
             chatGPTUser.username,
-            mikMapUser.username
+            mikMapUser.username,
         )
         assertThat(chartInfo.dataPoints).containsExactly(10.0, 10.0, 8.0, 7.0, 6.0)
     }

--- a/src/test/kotlin/sh/zachwal/dailygames/leaderboard/PointCalculatorTest.kt
+++ b/src/test/kotlin/sh/zachwal/dailygames/leaderboard/PointCalculatorTest.kt
@@ -29,7 +29,7 @@ class PointCalculatorTest {
         score = 5,
         shareText = "",
         resultInfo = WorldleInfo(
-            percentage = 100
+            percentage = 100,
         ),
     )
 
@@ -41,7 +41,7 @@ class PointCalculatorTest {
     private val flagleResult = worldleResult.copy(
         game = Game.FLAGLE,
         score = 6,
-        resultInfo = FlagleInfo
+        resultInfo = FlagleInfo,
     )
 
     @Test
@@ -66,7 +66,7 @@ class PointCalculatorTest {
         resultInfo = BandleInfo(
             numSkips = 0,
             numCorrectBand = 1,
-            numIncorrect = 3
+            numIncorrect = 3,
         ),
     )
 
@@ -154,8 +154,8 @@ class PointCalculatorTest {
             peeks = 0,
             answersRevealed = 0,
             totalScore = 98.0,
-            grid = ""
-        )
+            grid = "",
+        ),
     )
 
     @Test

--- a/src/test/kotlin/sh/zachwal/dailygames/leaderboard/TravlePointCalculatorTest.kt
+++ b/src/test/kotlin/sh/zachwal/dailygames/leaderboard/TravlePointCalculatorTest.kt
@@ -51,7 +51,7 @@ class TravlePointCalculatorTest {
         12 to 7,
         13 to 8,
         14 to 8,
-        15 to 8
+        15 to 8,
     )
 
     @Test
@@ -113,8 +113,8 @@ class TravlePointCalculatorTest {
             val result = travleResult.copy(
                 score = 0,
                 resultInfo = (travleResult.info<TravleInfo>()).copy(
-                    numGuesses = shortestSolution
-                )
+                    numGuesses = shortestSolution,
+                ),
             )
             assertThat(calculator.maxPoints(result)).isEqualTo(allowedIncorrect + 1)
         }
@@ -126,8 +126,8 @@ class TravlePointCalculatorTest {
             val result = travleResult.copy(
                 score = -allowedIncorrect,
                 resultInfo = (travleResult.info<TravleInfo>()).copy(
-                    numGuesses = shortestSolution + allowedIncorrect
-                )
+                    numGuesses = shortestSolution + allowedIncorrect,
+                ),
             )
             assertThat(calculator.maxPoints(result)).isEqualTo(allowedIncorrect + 1)
         }
@@ -139,8 +139,8 @@ class TravlePointCalculatorTest {
             val result = travleResult.copy(
                 score = -10,
                 resultInfo = (travleResult.info<TravleInfo>()).copy(
-                    numGuesses = shortestSolution + allowedIncorrect
-                )
+                    numGuesses = shortestSolution + allowedIncorrect,
+                ),
             )
             assertThat(calculator.maxPoints(result)).isEqualTo(allowedIncorrect + 1)
         }
@@ -158,7 +158,7 @@ class TravlePointCalculatorTest {
                 numGuesses = 10,
                 numIncorrect = 7,
                 numPerfect = 0,
-            )
+            ),
         )
 
         /**
@@ -171,7 +171,7 @@ class TravlePointCalculatorTest {
                 numGuesses = 5,
                 numIncorrect = 0,
                 numPerfect = 4,
-            )
+            ),
         )
 
         assertThat(calculator.maxPoints(resultTwoAway))
@@ -184,8 +184,8 @@ class TravlePointCalculatorTest {
             val result = travleResult.copy(
                 score = 1,
                 resultInfo = (travleResult.info<TravleInfo>()).copy(
-                    numGuesses = shortestSolution + 1
-                )
+                    numGuesses = shortestSolution + 1,
+                ),
             )
             assertThat(calculator.maxPoints(result)).isEqualTo(allowedIncorrect + 1)
         }

--- a/src/test/kotlin/sh/zachwal/dailygames/results/ResultServiceTest.kt
+++ b/src/test/kotlin/sh/zachwal/dailygames/results/ResultServiceTest.kt
@@ -56,7 +56,7 @@ private val tradle890 = """
 @ExtendWith(DatabaseExtension::class)
 class ResultServiceTest(
     jdbi: Jdbi,
-    private val fixtures: Fixtures
+    private val fixtures: Fixtures,
 ) {
 
     private val puzzleDAO = jdbi.onDemand<PuzzleDAO>()
@@ -106,7 +106,7 @@ class ResultServiceTest(
             🟩🟩🟩🟩🟨⬅️
             🟩🟩🟩🟩🟨↗️
             🟩🟩🟩🟩🟩🎉
-            """.trimIndent()
+            """.trimIndent(),
         )
 
         assertThat(result.resultInfo).isInstanceOf(WorldleInfo::class.java)
@@ -132,7 +132,7 @@ class ResultServiceTest(
             🟩🟩🟩🟩🟨
             🟩🟩🟩🟩🟨
             🟩🟩🟩🟩🟨
-            """.trimIndent()
+            """.trimIndent(),
         )
     }
 
@@ -148,7 +148,7 @@ class ResultServiceTest(
             """
             #travle #606 +2 (1 hint)
             ✅✅🟩🟧🟧✅
-            """.trimIndent()
+            """.trimIndent(),
         )
 
         assertThat(result.resultInfo).isInstanceOf(TravleInfo::class.java)
@@ -172,7 +172,7 @@ class ResultServiceTest(
             """
             Top 5 #171
             ⬜🟧🟨⬜⬜🟩⬜⬜
-            """.trimIndent()
+            """.trimIndent(),
         )
 
         assertThat(result.resultInfo).isInstanceOf(Top5Info::class.java)
@@ -196,7 +196,7 @@ class ResultServiceTest(
             #Flagle #905 (14.08.2024) X/6
             🟥🟥🟥
             🟥🟥🟥
-            """.trimIndent()
+            """.trimIndent(),
         )
     }
 
@@ -212,7 +212,7 @@ class ResultServiceTest(
             """
             Pinpoint #126
             🤔 🤔 📌 ⬜ ⬜ (3/5)
-            """.trimIndent()
+            """.trimIndent(),
         )
     }
 
@@ -229,7 +229,7 @@ class ResultServiceTest(
             Geocircles #55
             🟢🟢🟢🟢🟢
             ❤️❤️❤️❤️❤️
-            """.trimIndent()
+            """.trimIndent(),
         )
     }
 
@@ -245,7 +245,7 @@ class ResultServiceTest(
             """
             Framed #990
             🎥 🟥 🟥 🟥 🟩 ⬛ ⬛
-            """.trimIndent()
+            """.trimIndent(),
         )
         assertThat(result.info<FramedInfo>()).isEqualTo(FramedInfo)
     }
@@ -265,7 +265,7 @@ class ResultServiceTest(
             ✅ ✅ ✅
             Score: 123.3
             Rank: 3,618 / 11,718
-            """.trimIndent()
+            """.trimIndent(),
         )
     }
 
@@ -281,7 +281,7 @@ class ResultServiceTest(
             """
             Bandle #941 1/6
             🟩⬜⬜⬜⬜⬜
-            """.trimIndent()
+            """.trimIndent(),
         )
     }
 
@@ -300,7 +300,7 @@ class ResultServiceTest(
             
             Total Score: 100.0
             🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩
-            """.trimIndent()
+            """.trimIndent(),
         )
     }
 
@@ -360,7 +360,7 @@ class ResultServiceTest(
             #Worldle #935 (12.08.2024) 2/6 (100%)
             🟩🟩🟩🟩🟨⬅️
             🟩🟩🟩🟩🟩🎉
-            """.trimIndent()
+            """.trimIndent(),
         )
 
         val feedTitles = resultService.resultFeed(1L).map { it.resultTitle }
@@ -414,7 +414,7 @@ class ResultServiceTest(
             #Worldle #934 (12.08.2024) 2/6 (100%)
             🟩🟩🟩🟩🟨⬅️
             🟩🟩🟩🟩🟩🎉
-            """.trimIndent()
+            """.trimIndent(),
         )
         val differentPuzzleResult = resultService.createResult(fixtures.zach, tradle890)
 
@@ -458,7 +458,7 @@ class ResultServiceTest(
             resultInfo = WorldleInfo(
                 percentage = 100,
             ),
-            instantSubmitted = startOfToday.plusSeconds(3600)
+            instantSubmitted = startOfToday.plusSeconds(3600),
         )
 
         val hasResults = resultService.anyResultsToday(user)
@@ -489,7 +489,7 @@ class ResultServiceTest(
             resultInfo = WorldleInfo(
                 percentage = 100,
             ),
-            instantSubmitted = startOfToday.minusSeconds(3600)
+            instantSubmitted = startOfToday.minusSeconds(3600),
         )
 
         puzzleDAO.insertPuzzle(Puzzle(Game.WORLDLE, 798, null))
@@ -501,7 +501,7 @@ class ResultServiceTest(
             resultInfo = WorldleInfo(
                 percentage = 100,
             ),
-            instantSubmitted = endOfToday.plusSeconds(3600)
+            instantSubmitted = endOfToday.plusSeconds(3600),
         )
 
         val hasResults = resultService.anyResultsToday(user)
@@ -538,12 +538,14 @@ class ResultServiceTest(
 
         val counts = resultService.resultCountByGame(
             since = Instant.now().minusSeconds(10),
-            excludeUserId = fixtures.zach.id
+            excludeUserId = fixtures.zach.id,
         )
 
         assertThat(counts).containsExactly(
-            Game.TOP5, 1,
-            Game.FLAGLE, 1,
+            Game.TOP5,
+            1,
+            Game.FLAGLE,
+            1,
         )
     }
 }

--- a/src/test/kotlin/sh/zachwal/dailygames/results/ShareTextParserBandleTest.kt
+++ b/src/test/kotlin/sh/zachwal/dailygames/results/ShareTextParserBandleTest.kt
@@ -62,7 +62,7 @@ class ShareTextParserBandleTest {
             """
                 Bandle #941 1/6
                 🟩⬜⬜⬜⬜⬜
-            """.trimIndent()
+            """.trimIndent(),
         )
 
         assertThat(parsed.resultInfo).isInstanceOf(BandleInfo::class.java)
@@ -82,7 +82,7 @@ class ShareTextParserBandleTest {
             """
                 Bandle #941 x/6
                 🟥🟥🟥🟥🟥🟥
-            """.trimIndent()
+            """.trimIndent(),
         )
 
         assertThat(parsed.resultInfo).isInstanceOf(BandleInfo::class.java)
@@ -102,7 +102,7 @@ class ShareTextParserBandleTest {
             """
                 Bandle #941 4/6
                 🟨🟥🟨🟩⬜⬜
-            """.trimIndent()
+            """.trimIndent(),
         )
 
         assertThat(parsed.resultInfo).isInstanceOf(BandleInfo::class.java)
@@ -122,7 +122,7 @@ class ShareTextParserBandleTest {
             """
                 Bandle #941 x/6
                 ⬛⬛⬛⬛⬛⬛
-            """.trimIndent()
+            """.trimIndent(),
         )
 
         assertThat(parsed.resultInfo).isInstanceOf(BandleInfo::class.java)

--- a/src/test/kotlin/sh/zachwal/dailygames/results/ShareTextParserBracketCityTest.kt
+++ b/src/test/kotlin/sh/zachwal/dailygames/results/ShareTextParserBracketCityTest.kt
@@ -195,7 +195,7 @@ class ShareTextParserBracketCityTest {
             
             Total Score: 100.0
             🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩
-            """.trimIndent()
+            """.trimIndent(),
         )
     }
 }

--- a/src/test/kotlin/sh/zachwal/dailygames/results/ShareTextParserGeoGridTest.kt
+++ b/src/test/kotlin/sh/zachwal/dailygames/results/ShareTextParserGeoGridTest.kt
@@ -80,7 +80,7 @@ class ShareTextParserGeoGridTest {
                 ✅ ✅ ✅
                 Score: 123.3
                 Rank: 3,618 / 11,718
-            """.trimIndent()
+            """.trimIndent(),
         )
         val info = result.info<GeoGridInfo>()
         assertThat(info.score).isEqualTo(123.3)
@@ -100,7 +100,7 @@ class ShareTextParserGeoGridTest {
                 ❌ ❌ ❌
                 Score: 900
                 Rank: 10,188 / 11,737
-            """.trimIndent()
+            """.trimIndent(),
         )
         val info = result.info<GeoGridInfo>()
         assertThat(info.score).isEqualTo(900.0)
@@ -120,7 +120,7 @@ class ShareTextParserGeoGridTest {
                 ✅ ✅ ❌
                 Score: 382.7
                 Rank: 9,311 / 11,761
-            """.trimIndent()
+            """.trimIndent(),
         )
         val info = result.info<GeoGridInfo>()
         assertThat(info.score).isEqualTo(382.7)
@@ -140,7 +140,7 @@ class ShareTextParserGeoGridTest {
                 ✅ ✅ ✅
                 Score: 88.9
                 Rank: 1,521 / 11,795
-            """.trimIndent()
+            """.trimIndent(),
         )
         val info = result.info<GeoGridInfo>()
         assertThat(info.score).isEqualTo(88.9)

--- a/src/test/kotlin/sh/zachwal/dailygames/results/ShareTextParserTest.kt
+++ b/src/test/kotlin/sh/zachwal/dailygames/results/ShareTextParserTest.kt
@@ -228,7 +228,7 @@ class ShareTextParserTest {
             🟩🟩🟩🟩🟨⬅️
             🟩🟩🟩🟩🟨↗️
             🟩🟩🟩🟩🟩🎉
-            """.trimIndent()
+            """.trimIndent(),
         )
         assertThat(result.game).isEqualTo(Game.WORLDLE)
 
@@ -272,7 +272,7 @@ class ShareTextParserTest {
             🟩🟩🟩🟩🟨⬅️
             🟩🟩🟩🟩🟨↗️
             🟩🟩🟩🟩🟩🎉
-            """.trimIndent()
+            """.trimIndent(),
         )
     }
 
@@ -302,7 +302,7 @@ class ShareTextParserTest {
             🟩🟩🟩🟩🟨
             🟩🟩🟩🟩🟨
             🟩🟩🟩🟩🟨
-            """.trimIndent()
+            """.trimIndent(),
         )
         assertThat(tradleInfo.game).isEqualTo(Game.TRADLE)
     }
@@ -317,7 +317,7 @@ class ShareTextParserTest {
             """
                 #travle #607 +0 (Perfect)
                 ✅✅✅✅✅✅✅
-            """.trimIndent()
+            """.trimIndent(),
         )
         assertThat(result.game).isEqualTo(Game.TRAVLE)
         assertThat(result.resultInfo).isInstanceOf(TravleInfo::class.java)
@@ -340,7 +340,7 @@ class ShareTextParserTest {
             """
                 #travle #607 +0
                 ✅✅✅🟩✅✅✅
-            """.trimIndent()
+            """.trimIndent(),
         )
         assertThat(result.resultInfo).isInstanceOf(TravleInfo::class.java)
 
@@ -362,7 +362,7 @@ class ShareTextParserTest {
             """
                 #travle #606 +2 (1 hint)
                 ✅✅🟩🟧🟧✅
-            """.trimIndent()
+            """.trimIndent(),
         )
         assertThat(result.resultInfo).isInstanceOf(TravleInfo::class.java)
 
@@ -384,7 +384,7 @@ class ShareTextParserTest {
             """
                 #travle #614 (3 away)
                 🟧🟥🟥🟥🟧🟥🟥🟥✅
-            """.trimIndent()
+            """.trimIndent(),
         )
         assertThat(result.resultInfo).isInstanceOf(TravleInfo::class.java)
 
@@ -405,7 +405,7 @@ class ShareTextParserTest {
             """
                 Top 5 #171
                 ⬜🟧🟨⬜⬜🟩⬜⬜
-            """.trimIndent()
+            """.trimIndent(),
         )
         assertThat(result.score).isEqualTo(3)
         assertThat(result.game).isEqualTo(Game.TOP5)
@@ -426,7 +426,7 @@ class ShareTextParserTest {
             """
                 Top 5 #170
                 🟥⬜🟩🟨🟦⬜⬜⬜🟧
-            """.trimIndent()
+            """.trimIndent(),
         )
         assertThat(result.score).isEqualTo(6)
 
@@ -447,7 +447,7 @@ class ShareTextParserTest {
             """
                 Top 5 #169
                 🟥🟩🟧🟦🟨
-            """.trimIndent()
+            """.trimIndent(),
         )
         assertThat(result.score).isEqualTo(10)
 
@@ -468,7 +468,7 @@ class ShareTextParserTest {
             """
                 Top 5 #169
                 🟥🟧🟨🟩🟦
-            """.trimIndent()
+            """.trimIndent(),
         )
         assertThat(result.score).isEqualTo(10)
 
@@ -493,7 +493,7 @@ class ShareTextParserTest {
                 #Flagle #905 (14.08.2024) X/6
                 🟥🟥🟥
                 🟥🟥🟥
-            """.trimIndent()
+            """.trimIndent(),
         )
         assertThat(flagleInfo.resultInfo).isInstanceOf(FlagleInfo::class.java)
     }
@@ -510,7 +510,7 @@ class ShareTextParserTest {
                 #Flagle #905 (14.08.2024) 2/6
                 🟥🟩🟩
                 🟩🟩🟩
-            """.trimIndent()
+            """.trimIndent(),
         )
     }
 
@@ -525,7 +525,7 @@ class ShareTextParserTest {
             """
                 Pinpoint #126
                 🤔 🤔 📌 ⬜ ⬜ (3/5)
-            """.trimIndent()
+            """.trimIndent(),
         )
         assertThat(pinpointInfo.resultInfo).isInstanceOf(PinpointInfo::class.java)
     }
@@ -541,7 +541,7 @@ class ShareTextParserTest {
             """
                 Pinpoint #123
                 🤔 🤔 🤔 🤔 🤔 (X/5)
-            """.trimIndent()
+            """.trimIndent(),
         )
     }
 
@@ -555,7 +555,7 @@ class ShareTextParserTest {
             """
                 Pinpoint #126
                 🤔 🤔 📌 ⬜ ⬜ (3/5)
-            """.trimIndent()
+            """.trimIndent(),
         )
     }
 }

--- a/src/test/kotlin/sh/zachwal/dailygames/results/resultinfo/DeserializeStoredPuzzleResultInfoTest.kt
+++ b/src/test/kotlin/sh/zachwal/dailygames/results/resultinfo/DeserializeStoredPuzzleResultInfoTest.kt
@@ -26,19 +26,24 @@ class DeserializeStoredPuzzleResultInfoTest {
         @JvmStatic
         fun arguments(): List<Arguments> = listOf(
             Arguments.of(
-                "{\"type\":\"worldle\",\"percentage\":100}", WorldleInfo(percentage = 100)
+                "{\"type\":\"worldle\",\"percentage\":100}",
+                WorldleInfo(percentage = 100),
             ),
             Arguments.of(
-                "{\"type\":\"pinpoint\"}", PinpointInfo
+                "{\"type\":\"pinpoint\"}",
+                PinpointInfo,
             ),
             Arguments.of(
-                "{\"type\":\"geocircles\"}", GeocirclesInfo
+                "{\"type\":\"geocircles\"}",
+                GeocirclesInfo,
             ),
             Arguments.of(
-                "{\"type\":\"tradle\"}", TradleInfo
+                "{\"type\":\"tradle\"}",
+                TradleInfo,
             ),
             Arguments.of(
-                "{\"type\":\"flagle\"}", FlagleInfo
+                "{\"type\":\"flagle\"}",
+                FlagleInfo,
             ),
             Arguments.of(
                 "{\"type\":\"travle\",\"numGuesses\":6,\"numIncorrect\":0,\"numPerfect\":5,\"numHints\":0}",
@@ -47,7 +52,7 @@ class DeserializeStoredPuzzleResultInfoTest {
                     numIncorrect = 0,
                     numPerfect = 5,
                     numHints = 0,
-                )
+                ),
             ),
             Arguments.of(
                 "{\"type\":\"top5\",\"numGuesses\":5,\"numCorrect\":5,\"isPerfect\":true}",
@@ -55,7 +60,7 @@ class DeserializeStoredPuzzleResultInfoTest {
                     numGuesses = 5,
                     numCorrect = 5,
                     isPerfect = true,
-                )
+                ),
             ),
         )
     }

--- a/src/test/kotlin/sh/zachwal/dailygames/users/UserServiceTest.kt
+++ b/src/test/kotlin/sh/zachwal/dailygames/users/UserServiceTest.kt
@@ -35,7 +35,7 @@ class UserServiceTest(
             user = fixtures.zach,
             currentPassword = "hashedPassword",
             newPassword = "newPassword",
-            repeatNewPassword = "differentNewPassword"
+            repeatNewPassword = "differentNewPassword",
         )
 
         assertThat(result).isInstanceOf(ChangePasswordFailure::class.java)
@@ -49,7 +49,7 @@ class UserServiceTest(
             user = fixtures.zach,
             currentPassword = "wrongPassword",
             newPassword = "newPassword",
-            repeatNewPassword = "newPassword"
+            repeatNewPassword = "newPassword",
         )
 
         assertThat(result).isInstanceOf(ChangePasswordFailure::class.java)
@@ -63,7 +63,7 @@ class UserServiceTest(
             user = fixtures.zach,
             currentPassword = fixtures.zachPassword,
             newPassword = "newPassword",
-            repeatNewPassword = "newPassword"
+            repeatNewPassword = "newPassword",
         )
 
         assertThat(result).isEqualTo(ChangePasswordSuccess)

--- a/src/test/kotlin/sh/zachwal/dailygames/utils/DisplayTimeTest.kt
+++ b/src/test/kotlin/sh/zachwal/dailygames/utils/DisplayTimeTest.kt
@@ -113,7 +113,7 @@ class DisplayTimeTest {
                 yesterdayNoonPacific,
                 1L,
                 now = todayNoonPacific,
-            )
+            ),
         ).isEqualTo("Yesterday at 12:00PM PT")
     }
 

--- a/src/test/kotlin/sh/zachwal/dailygames/wrapped/WrappedServiceTest.kt
+++ b/src/test/kotlin/sh/zachwal/dailygames/wrapped/WrappedServiceTest.kt
@@ -36,7 +36,7 @@ class WrappedServiceTest {
         shareText = "",
         resultInfo = WorldleInfo(
             percentage = 100,
-        )
+        ),
     )
     private val resultDAO = mockk<PuzzleResultDAO>()
     private val jdbi = mockk<Jdbi> {
@@ -62,7 +62,7 @@ class WrappedServiceTest {
         every {
             resultDAO.allResultsBetweenStream(
                 Instant.parse("2024-01-01T05:00:00Z"),
-                Instant.parse("2025-01-01T05:00:00Z")
+                Instant.parse("2025-01-01T05:00:00Z"),
             )
         } returns Stream.empty()
 
@@ -72,7 +72,7 @@ class WrappedServiceTest {
         verify {
             resultDAO.allResultsBetweenStream(
                 Instant.parse("2024-01-01T05:00:00Z"),
-                Instant.parse("2025-01-01T05:00:00Z")
+                Instant.parse("2025-01-01T05:00:00Z"),
             )
         }
     }
@@ -112,8 +112,10 @@ class WrappedServiceTest {
 
         val userOne = wrappedData.single { it.userId == 1L }
         assertThat(userOne.gamesPlayedByGame).containsExactly(
-            Game.WORLDLE, 3,
-            Game.GEOCIRCLES, 2,
+            Game.WORLDLE,
+            3,
+            Game.GEOCIRCLES,
+            2,
         )
     }
 
@@ -131,8 +133,10 @@ class WrappedServiceTest {
 
         val userOne = wrappedData.single { it.userId == 1L }
         assertThat(userOne.pointsByGame).containsExactly(
-            Game.WORLDLE, 14,
-            Game.GEOCIRCLES, 15,
+            Game.WORLDLE,
+            14,
+            Game.GEOCIRCLES,
+            15,
         )
     }
 
@@ -344,8 +348,10 @@ class WrappedServiceTest {
 
         val userOne = wrappedData.single { it.userId == 1L }
         assertThat(userOne.averagesByGame).containsAtLeast(
-            Game.WORLDLE, 4.7,
-            Game.GEOCIRCLES, 7.5,
+            Game.WORLDLE,
+            4.7,
+            Game.GEOCIRCLES,
+            7.5,
         )
     }
 
@@ -363,14 +369,18 @@ class WrappedServiceTest {
 
         val userOne = wrappedData.single { it.userId == 1L }
         assertThat(userOne.ranksPerGameTotal).containsAtLeast(
-            Game.WORLDLE, 1,
-            Game.GEOCIRCLES, 2
+            Game.WORLDLE,
+            1,
+            Game.GEOCIRCLES,
+            2,
         )
 
         val userTwo = wrappedData.single { it.userId == 2L }
         assertThat(userTwo.ranksPerGameTotal).containsAtLeast(
-            Game.WORLDLE, 2,
-            Game.GEOCIRCLES, 1
+            Game.WORLDLE,
+            2,
+            Game.GEOCIRCLES,
+            1,
         )
     }
 
@@ -394,18 +404,20 @@ class WrappedServiceTest {
 
         val userOne = wrappedData.single { it.userId == 1L }
         assertThat(userOne.ranksPerGameAverage).containsAtLeast(
-            Game.WORLDLE, 2
+            Game.WORLDLE,
+            2,
         )
         val userTwo = wrappedData.single { it.userId == 2L }
         assertThat(userTwo.ranksPerGameAverage).containsAtLeast(
-            Game.WORLDLE, 1
+            Game.WORLDLE,
+            1,
         )
     }
 
     @Test
     fun `user ranks do not include games where the user played less than 10 games`() {
         every { resultDAO.allResultsBetweenStream(any(), any()) } returns Stream.of(
-            result
+            result,
         )
 
         val wrappedData = service.generateWrappedData(2024)
@@ -447,7 +459,7 @@ class WrappedServiceTest {
     @Test
     fun `best game is null if user does not qualify for any game`() {
         every { resultDAO.allResultsBetweenStream(any(), any()) } returns Stream.of(
-            result
+            result,
         )
 
         val wrappedData = service.generateWrappedData(2024)
@@ -538,7 +550,7 @@ class WrappedServiceTest {
     @Test
     fun `caches wrapped data for one user`() {
         every { resultDAO.allResultsBetweenStream(any(), any()) } returns Stream.of(
-            result
+            result,
         )
 
         val currentUser = User(1, "name", "password")


### PR DESCRIPTION
## Summary

- **Gradle 7.1 → 9.0.0** (via 8.13 as an intermediate validation step)
- **Kotlin Gradle Plugin 1.8.22 → 2.1.21** — required because the older plugin used the `Convention` API that was removed in Gradle 9
- **ktlint plugin 10.2.1 → 12.1.2** — required for Gradle 9 compatibility; upgrades underlying ktlint 0.x → 1.x
- **Added `.editorconfig`** with `ktlint_code_style = intellij_idea` to preserve existing code style under ktlint 1.x (which changed its default to `ktlint_official`); also disables new rules that would require unrelated formatting churn
- **`kotlinOptions {}` → `kotlin { compilerOptions {} }`** — old DSL deprecated in KGP 2.x
- **Auto-formatted source files** for rules ktlint 1.x can fix automatically (trailing whitespace, blank lines, etc.)

## Test plan

- [x] `./gradlew compileKotlin` — passes with zero deprecation warnings
- [x] `./gradlew ktlintCheck` — passes with new ktlint 1.x + intellij_idea style
- [x] `./gradlew build` — full build + tests pass on Gradle 9.0.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)