### PR TITLE
Switch to GitHub Releases-based CD

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,6 +27,21 @@ pipeline {
                 sh './gradlew build'
             }
         }
+        stage('release') {
+            when {
+                expression { env.GIT_BRANCH == 'origin/main' }
+            }
+            steps {
+                sh '''
+                    gh release create "sha-${GIT_COMMIT}" \
+                      build/distributions/dailygames.tar \
+                      --title "sha-${GIT_COMMIT}" \
+                      --notes "" \
+                      --latest \
+                      --repo zwalsh/dailygames
+                '''
+            }
+        }
     }
     post {
         success {

--- a/docs/releases-cd/plan.md
+++ b/docs/releases-cd/plan.md
@@ -1,0 +1,122 @@
+# CD Migration: GitHub Releases-Based Deployment
+
+## Goal
+
+Eliminate server-side compilation. Jenkins builds the tarball once, uploads it as a GitHub
+release, and production pulls the pre-built artifact. Test deployments remain source-based but
+become intentional (label-triggered) rather than automatic.
+
+## Motivation
+
+The current `deploy.sh` compiles the Kotlin codebase on the server for every deploy, which is
+memory-intensive. This also means two separate compilations per main merge: Jenkins and
+dailygames. Moving to pre-built releases removes the JDK/Gradle runtime requirement from the
+server entirely for production, and reduces test builds to on-demand only.
+
+## Architecture
+
+```
+Jenkins (any agent)                    Production server
+──────────────────                     ─────────────────────────────────────────
+assemble                               [timer fires every 1 min]
+ktlintCheck                            deploy.sh --env dailygames
+gradle build             ──────▶         gh release list --json → latest tag
+gh release create ◀─────────────         curl CI status; skip if not green
+setBuildStatus                           gh release download dailygames.tar
+                                         tar -xf into ~/releases/$TAG/
+                                         git checkout $SHA (for migrations)
+                                         db/migrate.sh
+                                         ln -sfn ~/releases/$TAG ~/releases/current
+                                         sudo systemctl restart dailygames
+                                         echo $TAG > ~/deployed_commit
+
+Developer labels PR "deploy-test"      Test server (manual/intentional)
+──────────────────────────────────     ────────────────────────────────────────
+                                       test-deploy.sh
+                                         Part 1: run migrations from latest release
+                                         Part 2: gh pr list --label deploy-test
+                                           find most-recently-updated PR
+                                           check CI status = success for HEAD SHA
+                                           git checkout $SHA
+                                           ./gradlew assemble
+                                           unpack, symlink, restart testdailygames
+```
+
+## Changes to Existing Files
+
+### `Jenkinsfile`
+
+Add a `release` stage between `test` and `setBuildStatus`, running only on `main`:
+
+```groovy
+stage('release') {
+    when { expression { env.GIT_BRANCH == 'origin/main' } }
+    steps {
+        sh '''
+            gh release create "sha-${GIT_COMMIT}" \
+              build/distributions/dailygames.tar \
+              --title "sha-${GIT_COMMIT}" \
+              --notes "" \
+              --latest \
+              --repo zwalsh/dailygames
+        '''
+    }
+}
+```
+
+The `gh` CLI must be available on agents. Jenkins uses the existing `GITHUB_TOKEN` credential
+(which already has `Contents: write` scope).
+
+`setBuildStatus` fires after `release`, so the asset exists before CI is marked green.
+
+### `scripts/deploy.sh` (prod only, simplified)
+
+Replace the checkout + build + unpack block with a download:
+
+1. `gh release list` → get latest tag name and derive SHA
+2. Read `~/deployed_commit`; exit 0 if tag already deployed
+3. Query GitHub commit status API; exit 0 if not `success`
+4. `gh release download` → `/tmp/dailygames.tar`
+5. `mkdir -p ~/releases/$TAG && tar -xf /tmp/dailygames.tar -C ~/releases/$TAG`
+6. `git checkout $SHA` (to get current migration files)
+7. `db/migrate.sh`
+8. `ln -sfn ~/releases/$TAG ~/releases/current`
+9. `sudo systemctl restart dailygames`
+10. `echo $TAG > ~/deployed_commit`
+11. Prune old releases (keep 3 most recent)
+
+The testdailygames path now just logs and exits; use `test-deploy.sh` instead.
+
+### `scripts/testdailygames-deploy.service`
+
+`ExecStart` updated from `deploy.sh --env testdailygames` to `test-deploy.sh`.
+
+## Files Added
+
+- `scripts/test-deploy.sh` — source-based deploy for testdailygames, label-gated
+- `docs/releases-cd/plan.md` — this file
+
+## Credential Changes
+
+| Credential                                   | Where   | Change                                                                                                     |
+|----------------------------------------------|---------|------------------------------------------------------------------------------------------------------------|
+| `GITHUB_TOKEN` (Contents: write)             | Jenkins | Already present — used for `setBuildStatus`; `Contents: write` already in scope                           |
+| `~/.github_token` on dailygames server       | Server  | No change — `Commit statuses: read` is sufficient; asset downloads use `gh` with the same token           |
+| `~/.github_token` on testdailygames server   | Server  | Needs `Pull requests: read` added (for `gh pr list`) — regenerate the PAT                                  |
+
+## Release Naming and Discovery
+
+Releases are tagged `sha-$GIT_COMMIT` (the full 40-char SHA). `deploy.sh` uses
+`gh release list --json tagName,isLatest` to find the latest release, then checks CI before
+switching. This is safe because Jenkins only creates releases on `main` after a successful
+build, and `setBuildStatus` fires after the upload.
+
+## Rollout Order
+
+1. Merge this PR to main. Jenkins creates the first release.
+2. Confirm `gh release list --json tagName,isLatest` returns the expected tag on the prod server.
+3. Run `deploy.sh --env dailygames` manually once to verify the end-to-end prod flow.
+4. Regenerate the testdailygames server token to add `Pull requests: read`.
+5. Run `test-deploy.sh` manually on the test server (with a labeled PR) to verify.
+6. Update the systemd service files on both servers (`sudo bash scripts/install-timers.sh`).
+7. Re-enable both timers.

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -21,86 +21,85 @@ fi
 REPO=~/dailygames
 TOKEN=$(cat ~/.github_token)
 
-# 1. Fetch latest refs
-log "[$ENV] Fetching latest refs"
-git -C "$REPO" fetch origin
-
-# 2. Resolve target SHA
-if [[ "$ENV" == "dailygames" ]]; then
-    SHA=$(git -C "$REPO" rev-parse origin/main)
-else
-    SHA=$(git -C "$REPO" for-each-ref \
-        --sort=-committerdate \
-        --format='%(refname:short) %(objectname)' \
-        'refs/remotes/origin/*' | \
-        grep -v 'origin/HEAD' | \
-        awk 'NR==1{print $2}')
-fi
-log "[$ENV] Target SHA: $SHA"
-
-# 3. Exit if already deployed
-DEPLOYED_FILE=~/deployed_commit
-if [[ -f "$DEPLOYED_FILE" ]] && [[ "$(cat "$DEPLOYED_FILE")" == "$SHA" ]]; then
-    log "[$ENV] SHA $SHA already deployed, nothing to do"
-    exit 0
-fi
-
-# 4. Exit if CI status is not success
-STATUS=$(curl -s "https://api.github.com/repos/zwalsh/dailygames/commits/$SHA/status" \
-    -H "Authorization: token $TOKEN" | jq -r '.state // empty') || true
-log "[$ENV] CI status for $SHA: ${STATUS:-<empty>}"
-if [[ "$STATUS" != "success" ]]; then
-    log "[$ENV] CI not green (state=$STATUS), skipping deploy"
-    exit 0
-fi
-
-log "[$ENV] Starting deploy of $SHA"
-
 on_error() {
     local exit_code=$?
     local line=$1
-    log "[$ENV] DEPLOY FAILED at line $line (exit code $exit_code)"
+    log "[$ENV] *** DEPLOY FAILED *** at line $line (exit code $exit_code)"
+    log "[$ENV] Check the lines above for the error output from the failing command"
 }
 trap 'on_error $LINENO' ERR
 
-# 5. Check out the target commit
-log "[$ENV] Checking out $SHA"
 if [[ "$ENV" == "dailygames" ]]; then
-    git -C "$REPO" checkout -f main
-else
-    git -C "$REPO" -c advice.detachedHead=false checkout -f "$SHA"
-fi
+    # 1. Get latest release tag from GitHub
+    log "[dailygames] Fetching latest release"
+    TAG=$(GITHUB_TOKEN="$TOKEN" gh release list \
+        --repo zwalsh/dailygames \
+        --json tagName,isLatest \
+        --jq '.[] | select(.isLatest) | .tagName')
+    if [[ -z "$TAG" ]]; then
+        log "[dailygames] No release found"
+        exit 0
+    fi
+    SHA="${TAG#sha-}"
+    log "[dailygames] Latest release: $TAG (SHA: $SHA)"
 
-# 6. Build
-log "[$ENV] Building"
-"$REPO/gradlew" -p "$REPO" assemble
+    # 2. Exit if already deployed
+    DEPLOYED_FILE=~/deployed_commit
+    if [[ -f "$DEPLOYED_FILE" ]] && [[ "$(cat "$DEPLOYED_FILE")" == "$TAG" ]]; then
+        log "[dailygames] $TAG already deployed, nothing to do"
+        exit 0
+    fi
 
-# 7. Unpack into release directory
-RELEASE_DIR=~/releases/$SHA
-log "[$ENV] Unpacking to $RELEASE_DIR"
-mkdir -p "$RELEASE_DIR"
-tar -xf "$REPO/build/distributions/dailygames.tar" -C "$RELEASE_DIR"
+    # 3. Exit if CI status is not success
+    STATUS=$(curl -s "https://api.github.com/repos/zwalsh/dailygames/commits/$SHA/status" \
+        -H "Authorization: token $TOKEN" | jq -r '.state // empty') || true
+    log "[dailygames] CI status for $SHA: ${STATUS:-<empty>}"
+    if [[ "$STATUS" != "success" ]]; then
+        log "[dailygames] CI not green (state=$STATUS), skipping deploy"
+        exit 0
+    fi
 
-# 8. Run database migrations (testdailygames only migrates for commits on main)
-if [[ "$ENV" == "dailygames" ]] || git -C "$REPO" merge-base --is-ancestor "$SHA" origin/main; then
-    log "[$ENV] Running database migrations"
+    log "[dailygames] Starting deploy of $TAG"
+
+    # 4. Download release asset
+    log "[dailygames] Downloading release asset"
+    GITHUB_TOKEN="$TOKEN" gh release download "$TAG" \
+        --repo zwalsh/dailygames \
+        --pattern 'dailygames.tar' \
+        --dir /tmp/ \
+        --clobber
+
+    # 5. Unpack into release directory
+    RELEASE_DIR=~/releases/$TAG
+    log "[dailygames] Unpacking to $RELEASE_DIR"
+    mkdir -p "$RELEASE_DIR"
+    tar -xf /tmp/dailygames.tar -C "$RELEASE_DIR"
+
+    # 6. Update repo to release SHA so migration files are current
+    log "[dailygames] Checking out $SHA for migrations"
+    git -C "$REPO" fetch origin
+    git -C "$REPO" checkout -f "$SHA"
+
+    # 7. Run database migrations
+    log "[dailygames] Running database migrations"
     "$REPO/db/migrate.sh"
+
+    # 8. Atomically update the current symlink
+    log "[dailygames] Updating current symlink to $RELEASE_DIR"
+    ln -sfn "$RELEASE_DIR" ~/releases/current
+
+    # 9. Restart the service
+    log "[dailygames] Restarting dailygames service"
+    sudo systemctl restart dailygames
+
+    # 10. Record the deployed tag
+    echo "$TAG" > ~/deployed_commit
+    log "[dailygames] Deploy of $TAG complete"
+
+    # 11. Prune old releases, keeping the 3 most recent
+    log "[dailygames] Pruning old releases"
+    ls -t ~/releases/ | grep -v '^current$' | tail -n +4 | xargs -I{} rm -rf ~/releases/{}
+
 else
-    log "[$ENV] Skipping database migrations: $SHA is not on main"
+    log "[testdailygames] testdailygames deploys are not handled here; use test-deploy.sh"
 fi
-
-# 9. Atomically update the current symlink
-log "[$ENV] Updating current symlink to $RELEASE_DIR"
-ln -sfn "$RELEASE_DIR" ~/releases/current
-
-# 10. Restart the service
-log "[$ENV] Restarting $ENV service"
-sudo systemctl restart "$ENV"
-
-# 11. Record the deployed commit
-echo "$SHA" > "$DEPLOYED_FILE"
-log "[$ENV] Deploy of $SHA complete"
-
-# 12. Prune old releases, keeping the 3 most recent
-log "[$ENV] Pruning old releases"
-ls -t ~/releases/ | grep -v '^current$' | tail -n +4 | xargs -I{} rm -rf ~/releases/{}

--- a/scripts/test-deploy.sh
+++ b/scripts/test-deploy.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+set -euo pipefail
+
+log() {
+    echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] $*"
+}
+
+REPO="${DAILYGAMES_REPO:-$HOME/dailygames}"
+TOKEN=$(cat ~/.github_token)
+MIGRATED_FILE=~/migrated_release
+DEPLOYED_FILE=~/deployed_commit
+
+on_error() {
+    local exit_code=$?
+    local line=$1
+    log "[testdailygames] *** DEPLOY FAILED *** at line $line (exit code $exit_code)"
+    log "[testdailygames] Check the lines above for the error output from the failing command"
+}
+trap 'on_error $LINENO' ERR
+
+# =============================================================================
+# Part 1: Run migrations from the latest GitHub release
+# Keeps testdailygames's schema in sync with main, independent of PR deploys.
+# =============================================================================
+
+run_migrations() {
+    log "[testdailygames] Checking latest GitHub release"
+    local TAG
+    TAG=$(GITHUB_TOKEN="$TOKEN" gh release list \
+        --repo zwalsh/dailygames \
+        --json tagName,isLatest \
+        --jq '.[] | select(.isLatest) | .tagName')
+
+    if [[ -z "$TAG" ]]; then
+        log "[testdailygames] No release found, skipping migrations"
+        return 0
+    fi
+
+    local RELEASE_SHA="${TAG#sha-}"
+    log "[testdailygames] Latest release: $TAG (SHA: $RELEASE_SHA)"
+
+    local MIGRATED_TAG=""
+    if [[ -f "$MIGRATED_FILE" ]]; then
+        MIGRATED_TAG=$(cat "$MIGRATED_FILE")
+    fi
+    log "[testdailygames] Last migrated release: ${MIGRATED_TAG:-<none>}"
+
+    if [[ "$MIGRATED_TAG" == "$TAG" ]]; then
+        log "[testdailygames] Migrations already up to date"
+        return 0
+    fi
+
+    local RELEASE_STATUS
+    RELEASE_STATUS=$(curl -s "https://api.github.com/repos/zwalsh/dailygames/commits/$RELEASE_SHA/status" \
+        -H "Authorization: token $TOKEN" | jq -r '.state // empty') || true
+    log "[testdailygames] CI status for release $TAG: ${RELEASE_STATUS:-<empty>}"
+
+    if [[ "$RELEASE_STATUS" != "success" ]]; then
+        log "[testdailygames] Release CI not green, skipping migrations"
+        return 0
+    fi
+
+    log "[testdailygames] Checking out $TAG for migrations"
+    git -C "$REPO" fetch origin
+    git -C "$REPO" -c advice.detachedHead=false checkout -f "$RELEASE_SHA"
+
+    log "[testdailygames] Running database migrations"
+    "$REPO/db/migrate.sh"
+
+    echo "$TAG" > "$MIGRATED_FILE"
+    log "[testdailygames] Migrations complete for $TAG"
+}
+
+run_migrations
+
+# =============================================================================
+# Part 2: Deploy the most-recently-updated open PR labeled deploy-test
+# Builds from source and restarts testdailygames. Runs independently of migrations.
+# =============================================================================
+
+log "[testdailygames] Checking for PRs labeled deploy-test"
+PR_JSON=$(GITHUB_TOKEN="$TOKEN" gh pr list \
+    --label deploy-test \
+    --state open \
+    --json number,headRefName,headRefOid,updatedAt \
+    --repo zwalsh/dailygames)
+
+PR_COUNT=$(echo "$PR_JSON" | jq 'length')
+log "[testdailygames] Found $PR_COUNT open PR(s) labeled deploy-test"
+
+SHA=$(echo "$PR_JSON" | jq -r 'sort_by(.updatedAt) | last | .headRefOid // empty')
+
+if [[ -z "$SHA" ]]; then
+    log "[testdailygames] No open PRs labeled deploy-test, nothing to deploy"
+    exit 0
+fi
+
+PR_NUMBER=$(echo "$PR_JSON" | jq -r 'sort_by(.updatedAt) | last | .number')
+PR_BRANCH=$(echo "$PR_JSON" | jq -r 'sort_by(.updatedAt) | last | .headRefName')
+log "[testdailygames] Target: PR #$PR_NUMBER ($PR_BRANCH) at SHA $SHA"
+
+PR_STATUS=$(curl -s "https://api.github.com/repos/zwalsh/dailygames/commits/$SHA/status" \
+    -H "Authorization: token $TOKEN" | jq -r '.state // empty') || true
+log "[testdailygames] CI status for $SHA: ${PR_STATUS:-<empty>}"
+if [[ "$PR_STATUS" != "success" ]]; then
+    log "[testdailygames] CI not green (state=$PR_STATUS), skipping deploy"
+    exit 0
+fi
+
+DEPLOYED_SHA=""
+if [[ -f "$DEPLOYED_FILE" ]]; then
+    DEPLOYED_SHA=$(cat "$DEPLOYED_FILE")
+fi
+log "[testdailygames] Currently deployed: ${DEPLOYED_SHA:-<none>}"
+if [[ "$DEPLOYED_SHA" == "$SHA" ]]; then
+    log "[testdailygames] SHA $SHA already deployed, nothing to do"
+    exit 0
+fi
+
+log "[testdailygames] Starting deploy of PR #$PR_NUMBER ($PR_BRANCH) at $SHA"
+
+log "[testdailygames] Fetching and checking out $SHA"
+git -C "$REPO" fetch origin
+git -C "$REPO" -c advice.detachedHead=false checkout -f "$SHA"
+
+log "[testdailygames] Building"
+"$REPO/gradlew" -p "$REPO" assemble
+
+RELEASE_DIR=~/releases/$SHA
+log "[testdailygames] Unpacking to $RELEASE_DIR"
+mkdir -p "$RELEASE_DIR"
+tar -xf "$REPO/build/distributions/dailygames.tar" -C "$RELEASE_DIR"
+
+log "[testdailygames] Updating current symlink to $RELEASE_DIR"
+ln -sfn "$RELEASE_DIR" ~/releases/current
+
+log "[testdailygames] Restarting testdailygames service"
+sudo systemctl restart testdailygames
+
+echo "$SHA" > "$DEPLOYED_FILE"
+log "[testdailygames] Deploy of PR #$PR_NUMBER at $SHA complete"
+
+log "[testdailygames] Pruning old releases"
+ls -t ~/releases/ | grep -v '^current$' | tail -n +4 | xargs -I{} rm -rf ~/releases/{}

--- a/scripts/testdailygames-deploy.service
+++ b/scripts/testdailygames-deploy.service
@@ -6,6 +6,6 @@ After=network.target
 Type=oneshot
 User=testdailygames
 EnvironmentFile=/home/testdailygames/dailygames.env
-ExecStart=/home/testdailygames/dailygames/scripts/deploy.sh --env testdailygames
+ExecStart=/home/testdailygames/dailygames/scripts/test-deploy.sh
 StandardOutput=journal
 StandardError=journal


### PR DESCRIPTION
## Summary

- **Jenkinsfile**: adds a `release` stage on `main` builds that uploads `dailygames.tar` as a GitHub release tagged `sha-$GIT_COMMIT`
- **`scripts/deploy.sh`**: prod path now downloads the pre-built release artifact via `gh release download` instead of compiling on the server; testdailygames path removed (now handled by `test-deploy.sh`)
- **`scripts/test-deploy.sh`** (new): two-part script for testdailygames — (1) runs Liquibase migrations from the latest release to keep the schema in sync with main, (2) deploys the most-recently-updated PR labeled `deploy-test`, building from source
- **`scripts/testdailygames-deploy.service`**: updated `ExecStart` to call `test-deploy.sh`
- **`docs/releases-cd/plan.md`**: documents the new architecture

## Post-merge steps

1. Confirm Jenkins creates the first release (check GitHub Releases page)
2. Run `deploy.sh --env dailygames` manually on prod to verify end-to-end
3. Label a test PR \`deploy-test\`, run \`test-deploy.sh\` manually on the test server to verify
4. \`sudo bash scripts/install-timers.sh\` on both servers to update the systemd service files
5. Re-enable both deploy timers

## Test plan

- [x] \`gh release list\` works as \`dailygames\` user on prod (returns empty — no releases yet)
- [x] \`gh pr list --label deploy-test\` works as \`testdailygames\` user on test server (returns \`[]\`)
- [x] CI status API curl+jq pipeline returns correct state for a known commit
- [ ] Jenkins creates release on merge to main
- [ ] \`deploy.sh --env dailygames\` deploys successfully from release artifact
- [ ] \`test-deploy.sh\` deploys labeled PR on test server

🤖 Generated with [Claude Code](https://claude.com/claude-code)